### PR TITLE
chain/waddrmgr/wallet: store all hashes for better reorg handling

### DIFF
--- a/chain/interface.go
+++ b/chain/interface.go
@@ -19,6 +19,7 @@ type Interface interface {
 	WaitForShutdown()
 	GetBestBlock() (*chainhash.Hash, int32, error)
 	GetBlock(*chainhash.Hash) (*wire.MsgBlock, error)
+	GetBlockHash(int64) (*chainhash.Hash, error)
 	BlockStamp() (*waddrmgr.BlockStamp, error)
 	SendRawTransaction(*wire.MsgTx, bool) (*chainhash.Hash, error)
 	Rescan(*chainhash.Hash, []btcutil.Address, []*wire.OutPoint) error

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -128,6 +128,18 @@ func (s *NeutrinoClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
 	}
 }
 
+// GetBlockHash returns the block hash for the given height, or an error if the
+// client has been shut down or the hash at the block height doesn't exist or
+// is unknown.
+func (s *NeutrinoClient) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	header, err := s.CS.BlockHeaders.FetchHeaderByHeight(uint32(height))
+	if err != nil {
+		return nil, err
+	}
+	hash := header.BlockHash()
+	return &hash, nil
+}
+
 // SendRawTransaction replicates the RPC client's SendRawTransaction command.
 func (s *NeutrinoClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
 	*chainhash.Hash, error) {

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg"
-	"github.com/roasbeef/btcd/chaincfg/chainhash"
 	"github.com/roasbeef/btcutil"
 	"github.com/roasbeef/btcutil/hdkeychain"
 	"github.com/roasbeef/btcwallet/internal/zero"
@@ -2130,11 +2129,6 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chai
 		return nil, maybeConvertDbError(err)
 	}
 
-	recentHeight, recentHashes, err := fetchRecentBlocks(ns)
-	if err != nil {
-		return nil, maybeConvertDbError(err)
-	}
-
 	// When not a watching-only manager, set the master private key params,
 	// but don't derive it now since the manager starts off locked.
 	var masterKeyPriv snacl.SecretKey
@@ -2169,7 +2163,7 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chai
 	zero.Bytes(cryptoKeyPubCT)
 
 	// Create the sync state struct.
-	syncInfo := newSyncState(startBlock, syncedTo, recentHeight, recentHashes)
+	syncInfo := newSyncState(startBlock, syncedTo)
 
 	// Generate private passphrase salt.
 	var privPassphraseSalt [saltSize]byte
@@ -2409,9 +2403,7 @@ func Create(ns walletdb.ReadWriteBucket, seed, pubPassphrase, privPassphrase []b
 		createdAt := &BlockStamp{Hash: *chainParams.GenesisHash, Height: 0}
 
 		// Create the initial sync state.
-		recentHashes := []chainhash.Hash{createdAt.Hash}
-		recentHeight := createdAt.Height
-		syncInfo := newSyncState(createdAt, createdAt, recentHeight, recentHashes)
+		syncInfo := newSyncState(createdAt, createdAt)
 
 		// Save the master key params to the database.
 		pubParams := masterKeyPub.Marshal()
@@ -2447,12 +2439,6 @@ func Create(ns walletdb.ReadWriteBucket, seed, pubPassphrase, privPassphrase []b
 			return err
 		}
 		err = putStartBlock(ns, &syncInfo.startBlock)
-		if err != nil {
-			return err
-		}
-
-		// Save the initial recent blocks state.
-		err = putRecentBlocks(ns, recentHeight, recentHashes)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR stores all block hashes, keyed by height, in the `waddrmgr` namespace under the `sync` bucket. It also removes the the existing `recentblocks` method for detecting reorganizations, which currently breaks tests (fix is upcoming).