### PR TITLE
wallet: add logging and batching when catching up block hashes on startup/rescan

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -14,11 +14,11 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/lightninglabs/neutrino"
 	"github.com/roasbeef/btcwallet/chain"
 	"github.com/roasbeef/btcwallet/rpc/legacyrpc"
 	"github.com/roasbeef/btcwallet/wallet"
 	"github.com/roasbeef/btcwallet/walletdb"
-	"github.com/lightninglabs/neutrino"
 )
 
 var (
@@ -48,7 +48,11 @@ func walletMain() error {
 		return err
 	}
 	cfg = tcfg
-	defer backendLog.Flush()
+	defer func() {
+		if logRotator != nil {
+			logRotator.Close()
+		}
+	}()
 
 	// Show version at startup.
 	log.Infof("Version %s", version())

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -232,7 +232,6 @@ func (s *NeutrinoClient) NotifyReceived(addrs []btcutil.Address) error {
 	// If we have a rescan running, we just need to add the appropriate
 	// addresses to the watch list.
 	if s.scanning {
-		s.clientMtx.Unlock()
 		return s.rescan.Update(neutrino.AddAddrs(addrs...))
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 59de122918c56a47f9987706a303d54c95929728a1dd74e2f17f38b03274366e
-updated: 2017-06-05T18:12:20.300008456-07:00
+hash: 8f57e2b090be9737f3c4d3157b3675ff5df4a9182928089f48c68593fdc80776
+updated: 2017-06-29T21:02:00.000000000-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/btcsuite/btclog
-  version: 73889fb79bd687870312b6e40effcecffbd57d30
+  version: 266a29b6e5ad061d4c055cec1c0049e4aae47092
 - name: github.com/btcsuite/fastsha256
   version: 637e656429416087660c84436a2a035d69d54e2e
 - name: github.com/btcsuite/go-socks
@@ -23,8 +23,6 @@ imports:
   - salsa20/salsa
   - scrypt
   - ssh/terminal
-- name: github.com/btcsuite/seelog
-  version: ae8891d029dd3c269dcfd6f261ad23e761acd99f
 - name: github.com/btcsuite/websocket
   version: 31079b6807923eb23992c421b114992b95131b55
 - name: github.com/davecgh/go-spew
@@ -40,12 +38,12 @@ imports:
 - name: github.com/kkdai/bstream
   version: f391b8402d23024e7c0f624b31267a89998fca95
 - name: github.com/lightninglabs/neutrino
-  version: f0bdd0ea5a1b453e1e323bfbb454b0cecbcfe2fa
+  version: ccfa94a1c213e5df752c08c7edc30cb0a56d4dcf
   subpackages:
   - filterdb
   - headerfs
 - name: github.com/roasbeef/btcd
-  version: 4d38357cee3ed3843cd81a347e1573f037e0301e
+  version: 34fdda7d41cc47d9456550fd1147a77db89f601a
   subpackages:
   - addrmgr
   - blockchain
@@ -58,8 +56,12 @@ imports:
   - peer
   - txscript
   - wire
+- name: github.com/jrick/logrotate
+  version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
+  subpackages:
+  - rotator
 - name: github.com/roasbeef/btcrpcclient
-  version: 9a7826550df8071460e2f5dd6ed9139dcbf260b8
+  version: d0f4db8b4dad0ca3d569b804f21247c3dd96acbb
 - name: github.com/roasbeef/btcutil
   version: a259eaf2ec1b54653cdd67848a41867f280797ee
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -38,7 +38,7 @@ imports:
 - name: github.com/kkdai/bstream
   version: f391b8402d23024e7c0f624b31267a89998fca95
 - name: github.com/lightninglabs/neutrino
-  version: ccfa94a1c213e5df752c08c7edc30cb0a56d4dcf
+  version: 4adef705d073ee1337f1fe980a282abd03e0ba68
   subpackages:
   - filterdb
   - headerfs

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,6 @@ import:
   - ripemd160
   - scrypt
   - ssh/terminal
-- package: github.com/btcsuite/seelog
 - package: github.com/btcsuite/websocket
 - package: github.com/golang/protobuf
   subpackages:
@@ -43,6 +42,9 @@ import:
   - codes
   - credentials
   - grpclog
+- package: github.com/jrick/logrotate
+  subpackages:
+  - rotator
 testImport:
 - package: github.com/davecgh/go-spew
   subpackages:

--- a/log.go
+++ b/log.go
@@ -6,33 +6,72 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/btcsuite/btclog"
+	"github.com/jrick/logrotate/rotator"
+	"github.com/lightninglabs/neutrino"
 	"github.com/roasbeef/btcrpcclient"
 	"github.com/roasbeef/btcwallet/chain"
 	"github.com/roasbeef/btcwallet/rpc/legacyrpc"
 	"github.com/roasbeef/btcwallet/rpc/rpcserver"
 	"github.com/roasbeef/btcwallet/wallet"
 	"github.com/roasbeef/btcwallet/wtxmgr"
-	"github.com/btcsuite/seelog"
-	"github.com/lightninglabs/neutrino"
 )
 
-// Loggers per subsytem.  Note that backendLog is a seelog logger that all of
-// the subsystem loggers route their messages to.  When adding new subsystems,
-// add a reference here, to the subsystemLoggers map, and the useLogger
-// function.
+// logWriter implements an io.Writer that outputs to both standard output and
+// the write-end pipe of an initialized log rotator.
+type logWriter struct{}
+
+func (logWriter) Write(p []byte) (n int, err error) {
+	os.Stdout.Write(p)
+	logRotatorPipe.Write(p)
+	return len(p), nil
+}
+
+// Loggers per subsystem.  A single backend logger is created and all subsytem
+// loggers created from it will write to the backend.  When adding new
+// subsystems, add the subsystem logger variable here and to the
+// subsystemLoggers map.
+//
+// Loggers can not be used before the log rotator has been initialized with a
+// log file.  This must be performed early during application startup by calling
+// initLogRotator.
 var (
-	backendLog   = seelog.Disabled
-	log          = btclog.Disabled
-	walletLog    = btclog.Disabled
-	txmgrLog     = btclog.Disabled
-	chainLog     = btclog.Disabled
-	grpcLog      = btclog.Disabled
-	legacyRPCLog = btclog.Disabled
-	btcnLog      = btclog.Disabled
+	// backendLog is the logging backend used to create all subsystem loggers.
+	// The backend must not be used before the log rotator has been initialized,
+	// or data races and/or nil pointer dereferences will occur.
+	backendLog = btclog.NewBackend(logWriter{})
+
+	// logRotator is one of the logging outputs.  It should be closed on
+	// application shutdown.
+	logRotator *rotator.Rotator
+
+	// logRotatorPipe is the write-end pipe for writing to the log rotator.  It
+	// is written to by the Write method of the logWriter type.
+	logRotatorPipe *io.PipeWriter
+
+	log          = backendLog.Logger("BTCW")
+	walletLog    = backendLog.Logger("WLLT")
+	txmgrLog     = backendLog.Logger("TMGR")
+	chainLog     = backendLog.Logger("CHNS")
+	grpcLog      = backendLog.Logger("GRPC")
+	legacyRPCLog = backendLog.Logger("RPCS")
+	btcnLog      = backendLog.Logger("BTCN")
 )
+
+// Initialize package-global logger variables.
+func init() {
+	wallet.UseLogger(walletLog)
+	wtxmgr.UseLogger(txmgrLog)
+	chain.UseLogger(chainLog)
+	btcrpcclient.UseLogger(chainLog)
+	rpcserver.UseLogger(grpcLog)
+	legacyrpc.UseLogger(legacyRPCLog)
+	neutrino.UseLogger(btcnLog)
+}
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
 var subsystemLoggers = map[string]btclog.Logger{
@@ -45,78 +84,27 @@ var subsystemLoggers = map[string]btclog.Logger{
 	"BTCN": btcnLog,
 }
 
-// logClosure is used to provide a closure over expensive logging operations
-// so don't have to be performed when the logging level doesn't warrant it.
-type logClosure func() string
-
-// String invokes the underlying function and returns the result.
-func (c logClosure) String() string {
-	return c()
-}
-
-// newLogClosure returns a new closure over a function that returns a string
-// which itself provides a Stringer interface so that it can be used with the
-// logging system.
-func newLogClosure(c func() string) logClosure {
-	return logClosure(c)
-}
-
-// useLogger updates the logger references for subsystemID to logger.  Invalid
-// subsystems are ignored.
-func useLogger(subsystemID string, logger btclog.Logger) {
-	if _, ok := subsystemLoggers[subsystemID]; !ok {
-		return
-	}
-	subsystemLoggers[subsystemID] = logger
-
-	switch subsystemID {
-	case "BTCW":
-		log = logger
-	case "WLLT":
-		walletLog = logger
-		wallet.UseLogger(logger)
-	case "TXST":
-		txmgrLog = logger
-		wtxmgr.UseLogger(logger)
-	case "CHNS":
-		chainLog = logger
-		chain.UseLogger(logger)
-		btcrpcclient.UseLogger(logger)
-	case "GRPC":
-		grpcLog = logger
-		rpcserver.UseLogger(logger)
-	case "RPCS":
-		legacyRPCLog = logger
-		legacyrpc.UseLogger(logger)
-	case "BTCN":
-		btcnLog = logger
-		neutrino.UseLogger(logger)
-	}
-}
-
-// initSeelogLogger initializes a new seelog logger that is used as the backend
-// for all logging subsytems.
-func initSeelogLogger(logFile string) {
-	config := `
-        <seelog type="adaptive" mininterval="2000000" maxinterval="100000000"
-                critmsgcount="500" minlevel="trace">
-                <outputs formatid="all">
-                        <console />
-                        <rollingfile type="size" filename="%s" maxsize="10485760" maxrolls="3" />
-                </outputs>
-                <formats>
-                        <format id="all" format="%%Time %%Date [%%LEV] %%Msg%%n" />
-                </formats>
-        </seelog>`
-	config = fmt.Sprintf(config, logFile)
-
-	logger, err := seelog.LoggerFromConfigAsString(config)
+// initLogRotator initializes the logging rotater to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotater variables are used.
+func initLogRotator(logFile string) {
+	logDir, _ := filepath.Split(logFile)
+	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create logger: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
+	}
+	pr, pw := io.Pipe()
+	r, err := rotator.New(pr, logFile, 10*1024, false, 3)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)
 	}
 
-	backendLog = logger
+	go r.Run()
+
+	logRotator = r
+	logRotatorPipe = pw
 }
 
 // setLogLevel sets the logging level for provided subsystem.  Invalid
@@ -129,17 +117,8 @@ func setLogLevel(subsystemID string, logLevel string) {
 		return
 	}
 
-	// Default to info if the log level is invalid.
-	level, ok := btclog.LogLevelFromString(logLevel)
-	if !ok {
-		level = btclog.InfoLvl
-	}
-
-	// Create new logger for the subsystem if needed.
-	if logger == btclog.Disabled {
-		logger = btclog.NewSubsystemLogger(backendLog, subsystemID+": ")
-		useLogger(subsystemID, logger)
-	}
+	// Defaults to info if the log level is invalid.
+	level, _ := btclog.LevelFromString(logLevel)
 	logger.SetLevel(level)
 }
 

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -56,16 +56,21 @@ func (w *Wallet) handleChainNotifications() {
 			notificationName = "recvtx/redeemingtx"
 		case chain.FilteredBlockConnected:
 			// Atomically update for the whole block.
-			err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-				var err error
-				for _, rec := range n.RelevantTxs {
-					err = w.addRelevantTx(tx, rec, n.Block)
-					if err != nil {
-						return err
+			if len(n.RelevantTxs) > 0 {
+				err = walletdb.Update(w.db, func(
+					tx walletdb.ReadWriteTx) error {
+					var err error
+					for _, rec := range n.RelevantTxs {
+						err = w.addRelevantTx(tx, rec,
+							n.Block)
+						if err != nil {
+							return err
+						}
 					}
-				}
-				return nil
-			})
+					return nil
+				})
+			}
+			notificationName = "filteredblockconnected"
 
 		// The following are handled by the wallet's rescan
 		// goroutines, so just pass them there.

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -192,6 +192,8 @@ out:
 			// if it doesn't match the original hash returned by
 			// the notification, to roll back and restart the
 			// rescan.
+			log.Infof("Catching up block hashes to height %d, this"+
+				" might take a while", n.Height)
 			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 				startBlock := w.Manager.SyncedTo()
@@ -216,6 +218,7 @@ out:
 					"sync state for hash %v (height %d): %v",
 					n.Hash, n.Height, err)
 			}
+			log.Info("Done catching up block hashes")
 
 		case msg := <-w.rescanFinished:
 			n := msg.Notification
@@ -242,6 +245,8 @@ out:
 			// if it doesn't match the original hash returned by
 			// the notification, to roll back and restart the
 			// rescan.
+			log.Infof("Catching up block hashes to height %d, this"+
+				" might take a while", n.Height)
 			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 				startBlock := w.Manager.SyncedTo()
@@ -269,6 +274,7 @@ out:
 			}
 
 			w.SetChainSynced(true)
+			log.Info("Done catching up block hashes")
 			go w.resendUnminedTxs()
 
 		case <-quit:

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -356,6 +356,8 @@ func (w *Wallet) syncWithChain() error {
 		if err != nil {
 			return err
 		}
+		log.Infof("Catching up block hashes to height %d, this will "+
+			"take a while...", bestHeight)
 		// Initialize the first database transaction.
 		tx, err := w.db.BeginReadWriteTx()
 		if err != nil {
@@ -383,6 +385,7 @@ func (w *Wallet) syncWithChain() error {
 					tx.Rollback()
 					return err
 				}
+				log.Infof("Caught up to height %d", height)
 				tx, err = w.db.BeginReadWriteTx()
 				if err != nil {
 					return err
@@ -396,6 +399,7 @@ func (w *Wallet) syncWithChain() error {
 			tx.Rollback()
 			return err
 		}
+		log.Info("Done catching up block hashes")
 	}
 
 	// Compare previously-seen blocks against the chain server.  If any of


### PR DESCRIPTION
This PR adds some logging to make it obvious why a delay exists when catching up block hashes on startup and rescan. This is especially useful on first startup.

First startup is also enhanced by batching writes to only open/commit transactions every 10,000 writes. This speeds up startup compared to the previous method of opening/committing a transaction for each write.