### PR TITLE
wallet: close db on Open() failure.

### DIFF
--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -177,6 +177,13 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	}
 	w, err := Open(db, pubPassphrase, cbs, l.chainParams)
 	if err != nil {
+		// If opening the wallet fails (e.g. because of wrong
+		// passphrase), we must close the backing database to
+		// allow future calls to walletdb.Open().
+		e := db.Close()
+		if e != nil {
+			log.Warnf("Error closing database: %v", e)
+		}
 		return nil, err
 	}
 	w.Start()


### PR DESCRIPTION
This commit makes sure the wallet db is closed if the call to
open the wallet fails, as subsequent calls to OpenExistingWallet
would fail to open the already open database.