### PR TITLE
build+chain: replace pebbe/zmq4 with lightninglabs/gozmq (native Go)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 83bb1c0a0f5c6396d2387746544592662898af52596d5cdca898b6fbfaa60841
-updated: 2017-11-29T14:42:36.82153259-06:00
+hash: 8fdbf966a888ff626d377d985e34c32518f81e96dc661433184ce011bad062b2
+updated: 2018-01-12T18:42:39.220877425-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
@@ -44,8 +44,8 @@ imports:
   subpackages:
   - filterdb
   - headerfs
-- name: github.com/pebbe/zmq4
-  version: 90d69e412a09549f2e90bac70fbb449081f1e5c1
+- name: github.com/lightninglabs/gozmq
+  version: b0bbb30a99d00b25c3304994d20aac68607b75c0
 - name: github.com/roasbeef/btcd
   version: 5d9e4e1fa749fa2f1675802a4c9f10ef0ada04d1
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,7 +43,7 @@ import:
 - package: github.com/jrick/logrotate
   subpackages:
   - rotator
-- package: github.com/pebbe/zmq4
+- package: github.com/lightninglabs/gozmq
 testImport:
 - package: github.com/davecgh/go-spew
   subpackages:


### PR DESCRIPTION
This PR replaces a ZMQ binding that depends on C libraries with a pure Go library to keep cross-compilation easy.