### PR TITLE
Generalize the waddrmgr by creating the concept of a ScopedKeyManager

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -151,7 +151,7 @@ func (s *walletServer) Network(ctx context.Context, req *pb.NetworkRequest) (
 func (s *walletServer) AccountNumber(ctx context.Context, req *pb.AccountNumberRequest) (
 	*pb.AccountNumberResponse, error) {
 
-	accountNum, err := s.wallet.AccountNumber(req.AccountName)
+	accountNum, err := s.wallet.AccountNumber(waddrmgr.KeyScopeBIP0044, req.AccountName)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -162,7 +162,7 @@ func (s *walletServer) AccountNumber(ctx context.Context, req *pb.AccountNumberR
 func (s *walletServer) Accounts(ctx context.Context, req *pb.AccountsRequest) (
 	*pb.AccountsResponse, error) {
 
-	resp, err := s.wallet.Accounts()
+	resp, err := s.wallet.Accounts(waddrmgr.KeyScopeBIP0044)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -188,7 +188,7 @@ func (s *walletServer) Accounts(ctx context.Context, req *pb.AccountsRequest) (
 func (s *walletServer) RenameAccount(ctx context.Context, req *pb.RenameAccountRequest) (
 	*pb.RenameAccountResponse, error) {
 
-	err := s.wallet.RenameAccount(req.AccountNumber, req.NewName)
+	err := s.wallet.RenameAccount(waddrmgr.KeyScopeBIP0044, req.AccountNumber, req.NewName)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -214,7 +214,7 @@ func (s *walletServer) NextAccount(ctx context.Context, req *pb.NextAccountReque
 		return nil, translateError(err)
 	}
 
-	account, err := s.wallet.NextAccount(req.AccountName)
+	account, err := s.wallet.NextAccount(waddrmgr.KeyScopeBIP0044, req.AccountName)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -231,9 +231,9 @@ func (s *walletServer) NextAddress(ctx context.Context, req *pb.NextAddressReque
 	)
 	switch req.Kind {
 	case pb.NextAddressRequest_BIP0044_EXTERNAL:
-		addr, err = s.wallet.NewAddress(req.Account, waddrmgr.PubKeyHash)
+		addr, err = s.wallet.NewAddress(req.Account, waddrmgr.KeyScopeBIP0044)
 	case pb.NextAddressRequest_BIP0044_INTERNAL:
-		addr, err = s.wallet.NewChangeAddress(req.Account, waddrmgr.PubKeyHash)
+		addr, err = s.wallet.NewChangeAddress(req.Account, waddrmgr.KeyScopeBIP0044)
 	default:
 		return nil, grpc.Errorf(codes.InvalidArgument, "kind=%v", req.Kind)
 	}
@@ -271,7 +271,7 @@ func (s *walletServer) ImportPrivateKey(ctx context.Context, req *pb.ImportPriva
 			"Only the imported account accepts private key imports")
 	}
 
-	_, err = s.wallet.ImportPrivateKey(wif, nil, req.Rescan)
+	_, err = s.wallet.ImportPrivateKey(waddrmgr.KeyScopeBIP0044, wif, nil, req.Rescan)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -349,7 +349,7 @@ func (s *walletServer) FundTransaction(ctx context.Context, req *pb.FundTransact
 
 	var changeScript []byte
 	if req.IncludeChangeScript && totalAmount > btcutil.Amount(req.TargetAmount) {
-		changeAddr, err := s.wallet.NewChangeAddress(req.Account, waddrmgr.PubKeyHash)
+		changeAddr, err := s.wallet.NewChangeAddress(req.Account, waddrmgr.KeyScopeBIP0044)
 		if err != nil {
 			return nil, translateError(err)
 		}

--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -19,11 +19,22 @@ import (
 
 // AddressType represents the various address types waddrmgr is currently able
 // to generate, and maintain.
+//
+// NOTE: These MUST be stable as they're used for scope address schema
+// recognition within the database.
 type AddressType uint8
 
 const (
 	// PubKeyHash is a regular p2pkh address.
-	PubKeyHash AddressType = 1 << iota
+	PubKeyHash AddressType = iota
+
+	// Script reprints a raw script address.
+	Script
+
+	// RawPubKey is just raw public key to be used within scripts, This
+	// type indicates that a scoped manager with this address type
+	// shouldn't be consulted during historical rescans.
+	RawPubKey
 
 	// NestedWitnessPubKey represents a p2wkh output nested within a p2sh
 	// output. Using this address type, the wallet can receive funds from
@@ -33,24 +44,10 @@ const (
 	// compatible manner.
 	NestedWitnessPubKey
 
-	// WitnessPubKey represents a p2wkh (pay-to-witness-key-hash) address type.
+	// WitnessPubKey represents a p2wkh (pay-to-witness-key-hash) address
+	// type.
 	WitnessPubKey
 )
-
-// addressTypeToInternal converts the publicly exported address type to the
-// internal address type recognized by the database.
-func addressTypeToInternal(t AddressType) addressType {
-	switch t {
-	case PubKeyHash:
-		return adtChain
-	case NestedWitnessPubKey:
-		return adtChainNestedWitness
-	case WitnessPubKey:
-		return adtChainWitness
-	}
-
-	return adtChain
-}
 
 // ManagedAddress is an interface that provides acces to information regarding
 // an address managed by an address manager. Concrete implementations of this

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// LatestMgrVersion is the most recent manager version.
-	LatestMgrVersion = 4
+	LatestMgrVersion = 5
 )
 
 var (
@@ -2240,6 +2240,11 @@ func upgradeManager(db walletdb.DB, namespaceKey []byte, pubPassPhrase []byte,
 // * acctIDIdxBucketName
 // * metaBucketName
 func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPassPhrase []byte, chainParams *chaincfg.Params) error {
+	priorScope := &KeyScope{
+		Purpose: 44,
+		Coin:    chainParams.HDCoinType,
+	}
+
 	err := func() error {
 		currentMgrVersion := uint32(3)
 
@@ -2262,7 +2267,9 @@ func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPas
 		}
 
 		// Derive the cointype key according to BIP0044.
-		coinTypeKeyPriv, err := deriveCoinTypeKey(root, chainParams.HDCoinType)
+		coinTypeKeyPriv, err := deriveCoinTypeKey(
+			root, *priorScope,
+		)
 		if err != nil {
 			str := "failed to derive cointype extended key"
 			return managerError(ErrKeyChain, str, err)
@@ -2288,7 +2295,7 @@ func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPas
 		}
 
 		// Save the encrypted cointype keys to the database.
-		err = putCoinTypeKeys(ns, coinTypePubEnc, coinTypePrivEnc)
+		err = putCoinTypeKeys(ns, priorScope, coinTypePubEnc, coinTypePrivEnc)
 		if err != nil {
 			return err
 		}
@@ -2312,22 +2319,22 @@ func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPas
 		}
 
 		// Initialize metadata for all keys
-		if err := putLastAccount(ns, DefaultAccountNum); err != nil {
+		if err := putLastAccount(ns, priorScope, DefaultAccountNum); err != nil {
 			return err
 		}
 
 		// Update default account indexes
-		if err := putAccountIDIndex(ns, DefaultAccountNum, defaultAccountName); err != nil {
+		if err := putAccountIDIndex(ns, priorScope, DefaultAccountNum, defaultAccountName); err != nil {
 			return err
 		}
-		if err := putAccountNameIndex(ns, DefaultAccountNum, defaultAccountName); err != nil {
+		if err := putAccountNameIndex(ns, priorScope, DefaultAccountNum, defaultAccountName); err != nil {
 			return err
 		}
 		// Update imported account indexes
-		if err := putAccountIDIndex(ns, ImportedAddrAccount, ImportedAddrAccountName); err != nil {
+		if err := putAccountIDIndex(ns, priorScope, ImportedAddrAccount, ImportedAddrAccountName); err != nil {
 			return err
 		}
-		if err := putAccountNameIndex(ns, ImportedAddrAccount, ImportedAddrAccountName); err != nil {
+		if err := putAccountNameIndex(ns, priorScope, ImportedAddrAccount, ImportedAddrAccountName); err != nil {
 			return err
 		}
 
@@ -2337,7 +2344,7 @@ func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPas
 		}
 
 		// Save "" alias for default account name for backward compat
-		return putAccountNameIndex(ns, DefaultAccountNum, "")
+		return putAccountNameIndex(ns, priorScope, DefaultAccountNum, "")
 	}()
 	if err != nil {
 		return maybeConvertDbError(err)
@@ -2349,6 +2356,11 @@ func upgradeToVersion3(ns walletdb.ReadWriteBucket, seed, privPassPhrase, pubPas
 // default account remains unchanged (even if it was modified by the user), but
 // the empty string alias to the default account is removed.
 func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error {
+	priorScope := &KeyScope{
+		Purpose: 44,
+		Coin:    0,
+	}
+
 	err := func() error {
 		// Write new manager version.
 		err := putManagerVersion(ns, 4)
@@ -2358,11 +2370,11 @@ func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error 
 
 		// Lookup the old account info to determine the real name of the
 		// default account.  All other names will be removed.
-		acctInfoIface, err := fetchAccountInfo(ns, DefaultAccountNum)
+		acctInfoIface, err := fetchAccountInfo(ns, priorScope, DefaultAccountNum)
 		if err != nil {
 			return err
 		}
-		acctInfo, ok := acctInfoIface.(*dbBIP0044AccountRow)
+		acctInfo, ok := acctInfoIface.(*dbDefaultAccountRow)
 		if !ok {
 			str := fmt.Sprintf("unsupported account type %T", acctInfoIface)
 			return managerError(ErrDatabase, str, nil)
@@ -2398,7 +2410,7 @@ func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error 
 		// The account number to name index may map to the wrong name,
 		// so rewrite the entry with the true name from the account row
 		// instead of leaving it set to an incorrect alias.
-		err = putAccountIDIndex(ns, DefaultAccountNum, acctInfo.name)
+		err = putAccountIDIndex(ns, priorScope, DefaultAccountNum, acctInfo.name)
 		if err != nil {
 			const str = "account number to name index could not be " +
 				"rewritten with actual account name"
@@ -2407,7 +2419,7 @@ func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error 
 
 		// Ensure that the true name for the default account maps
 		// forwards and backwards to the default account number.
-		name, err := fetchAccountName(ns, DefaultAccountNum)
+		name, err := fetchAccountName(ns, priorScope, DefaultAccountNum)
 		if err != nil {
 			return err
 		}
@@ -2415,7 +2427,7 @@ func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error 
 			const str = "account name index does not map default account number to correct name"
 			return managerError(ErrUpgrade, str, nil)
 		}
-		acct, err := fetchAccountByName(ns, acctInfo.name)
+		acct, err := fetchAccountByName(ns, priorScope, acctInfo.name)
 		if err != nil {
 			return err
 		}
@@ -2426,7 +2438,7 @@ func upgradeToVersion4(ns walletdb.ReadWriteBucket, pubPassPhrase []byte) error 
 
 		// Ensure that looking up the default account by the old name
 		// cannot succeed.
-		_, err = fetchAccountByName(ns, oldName)
+		_, err = fetchAccountByName(ns, priorScope, oldName)
 		if err == nil {
 			const str = "default account exists under old name"
 			return managerError(ErrUpgrade, str, nil)

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -53,8 +53,8 @@ type syncStatus uint8
 
 // These constants define the various supported sync status types.
 //
-// NOTE: These are currently unused but are being defined for the possibility of
-// supporting sync status on a per-address basis.
+// NOTE: These are currently unused but are being defined for the possibility
+// of supporting sync status on a per-address basis.
 const (
 	ssNone    syncStatus = 0 // not iota as they need to be stable for db
 	ssPartial syncStatus = 1
@@ -66,11 +66,9 @@ type addressType uint8
 
 // These constants define the various supported address types.
 const (
-	adtChain              addressType = 0 // not iota as they need to be stable for db
-	adtImport             addressType = 1
-	adtScript             addressType = 2
-	adtChainWitness       addressType = 3
-	adtChainNestedWitness addressType = 4
+	adtChain  addressType = 0
+	adtImport addressType = 1 // not iota as they need to be stable for db
+	adtScript addressType = 2
 )
 
 // accountType represents a type of address stored in the database.

--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -127,6 +127,10 @@ const (
 	// ErrEmptyPassphrase indicates that the private passphrase was refused
 	// due to being empty.
 	ErrEmptyPassphrase
+
+	// ErrScopeNotFound is returned when a target scope cannot be found
+	// within the database.
+	ErrScopeNotFound
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -152,6 +156,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrWrongNet:          "ErrWrongNet",
 	ErrCallBackBreak:     "ErrCallBackBreak",
 	ErrEmptyPassphrase:   "ErrEmptyPassphrase",
+	ErrScopeNotFound:     "ErrScopeNotFound",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/waddrmgr/internal_test.go
+++ b/waddrmgr/internal_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/roasbeef/btcwallet/snacl"
 )
 
-// TstMaxRecentHashes makes the unexported maxRecentHashes constant available
-// when tests are run.
-var TstMaxRecentHashes = maxRecentHashes
-
 // TstLatestMgrVersion makes the unexported latestMgrVersion variable available
 // for change when the tests are run.
 var TstLatestMgrVersion = &latestMgrVersion

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -686,8 +686,8 @@ func (m *Manager) ForEachActiveAccountAddress(ns walletdb.ReadBucket,
 // ForEachActiveAddress calls the given function with each active address
 // stored in the manager, breaking early on error.
 func (m *Manager) ForEachActiveAddress(ns walletdb.ReadBucket, fn func(addr btcutil.Address) error) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
 
 	for _, scopedMgr := range m.scopedManagers {
 		err := scopedMgr.ForEachActiveAddress(ns, fn)
@@ -704,8 +704,8 @@ func (m *Manager) ForEachActiveAddress(ns walletdb.ReadBucket, fn func(addr btcu
 func (m *Manager) ForEachAccountAddress(ns walletdb.ReadBucket, account uint32,
 	fn func(maddr ManagedAddress) error) error {
 
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
 
 	for _, scopedMgr := range m.scopedManagers {
 		err := scopedMgr.ForEachAccountAddress(ns, account, fn)

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/roasbeef/btcd/btcec"
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcutil"
 	"github.com/roasbeef/btcutil/hdkeychain"
@@ -22,21 +21,21 @@ import (
 
 const (
 	// MaxAccountNum is the maximum allowed account number.  This value was
-	// chosen because accounts are hardened children and therefore must
-	// not exceed the hardened child range of extended keys and it provides
-	// a reserved account at the top of the range for supporting imported
+	// chosen because accounts are hardened children and therefore must not
+	// exceed the hardened child range of extended keys and it provides a
+	// reserved account at the top of the range for supporting imported
 	// addresses.
 	MaxAccountNum = hdkeychain.HardenedKeyStart - 2 // 2^31 - 2
 
 	// MaxAddressesPerAccount is the maximum allowed number of addresses
-	// per account number.  This value is based on the limitation of
-	// the underlying hierarchical deterministic key derivation.
+	// per account number.  This value is based on the limitation of the
+	// underlying hierarchical deterministic key derivation.
 	MaxAddressesPerAccount = hdkeychain.HardenedKeyStart - 1
 
 	// ImportedAddrAccount is the account number to use for all imported
-	// addresses.  This is useful since normal accounts are derived from the
-	// root hierarchical deterministic key and imported addresses do not
-	// fit into that model.
+	// addresses.  This is useful since normal accounts are derived from
+	// the root hierarchical deterministic key and imported addresses do
+	// not fit into that model.
 	ImportedAddrAccount = MaxAccountNum + 1 // 2^31 - 1
 
 	// ImportedAddrAccountName is the name of the imported account.
@@ -50,8 +49,8 @@ const (
 	// so the default account might not be named "default" and non-default
 	// accounts may be named "default".
 	//
-	// Account numbers never change, so the DefaultAccountNum should be used
-	// to refer to (and only to) the default account.
+	// Account numbers never change, so the DefaultAccountNum should be
+	// used to refer to (and only to) the default account.
 	defaultAccountName = "default"
 
 	// The hierarchy described by BIP0043 is:
@@ -82,9 +81,9 @@ const (
 	saltSize = 32
 )
 
-// isReservedAccountName returns true if the account name is reserved.  Reserved
-// accounts may never be renamed, and other accounts may not be renamed to a
-// reserved name.
+// isReservedAccountName returns true if the account name is reserved.
+// Reserved accounts may never be renamed, and other accounts may not be
+// renamed to a reserved name.
 func isReservedAccountName(name string) bool {
 	return name == ImportedAddrAccountName
 }
@@ -109,6 +108,7 @@ type OpenCallbacks struct {
 	// upgrades.  It is intended to be used to request the wallet seed
 	// from the user (or any other mechanism the caller deems fit).
 	ObtainSeed ObtainUserInputFunc
+
 	// ObtainPrivatePass is a callback function that is potentially invoked
 	// during upgrades.  It is intended to be used to request the wallet
 	// private passphrase from the user (or any other mechanism the caller
@@ -124,8 +124,8 @@ var DefaultScryptOptions = ScryptOptions{
 }
 
 // addrKey is used to uniquely identify an address even when those addresses
-// would end up being the same bitcoin address (as is the case for pay-to-pubkey
-// and pay-to-pubkey-hash style of addresses).
+// would end up being the same bitcoin address (as is the case for
+// pay-to-pubkey and pay-to-pubkey-hash style of addresses).
 type addrKey string
 
 // accountInfo houses the current state of the internal and external branches
@@ -137,14 +137,14 @@ type accountInfo struct {
 	acctName string
 
 	// The account key is used to derive the branches which in turn derive
-	// the internal and external addresses.
-	// The accountKeyPriv will be nil when the address manager is locked.
+	// the internal and external addresses.  The accountKeyPriv will be nil
+	// when the address manager is locked.
 	acctKeyEncrypted []byte
 	acctKeyPriv      *hdkeychain.ExtendedKey
 	acctKeyPub       *hdkeychain.ExtendedKey
 
-	// The external branch is used for all addresses which are intended
-	// for external use.
+	// The external branch is used for all addresses which are intended for
+	// external use.
 	nextExternalIndex uint32
 	lastExternalAddr  ManagedAddress
 
@@ -165,8 +165,9 @@ type AccountProperties struct {
 }
 
 // unlockDeriveInfo houses the information needed to derive a private key for a
-// managed address when the address manager is unlocked.  See the deriveOnUnlock
-// field in the Manager struct for more details on how this is used.
+// managed address when the address manager is unlocked.  See the
+// deriveOnUnlock field in the Manager struct for more details on how this is
+// used.
 type unlockDeriveInfo struct {
 	managedAddr ManagedAddress
 	branch      uint32
@@ -247,17 +248,19 @@ var newCryptoKey = defaultNewCryptoKey
 type Manager struct {
 	mtx sync.RWMutex
 
-	chainParams  *chaincfg.Params
-	addrs        map[addrKey]ManagedAddress
+	// scopedManager is a mapping of scope of scoped manager, the manager
+	// itself loaded into memory.
+	scopedManagers map[KeyScope]*ScopedKeyManager
+
+	externalAddrSchemas map[AddressType][]KeyScope
+	internalAddrSchemas map[AddressType][]KeyScope
+
 	syncState    syncState
-	birthday     time.Time
 	watchingOnly bool
+	birthday     time.Time
 	locked       bool
 	closed       bool
-
-	// acctInfo houses information about accounts including what is needed
-	// to generate deterministic chained keys for each created account.
-	acctInfo map[uint32]*accountInfo
+	chainParams  *chaincfg.Params
 
 	// masterKeyPub is the secret key used to secure the cryptoKeyPub key
 	// and masterKeyPriv is the secret key used to secure the cryptoKeyPriv
@@ -290,13 +293,6 @@ type Manager struct {
 	cryptoKeyScriptEncrypted []byte
 	cryptoKeyScript          EncryptorDecryptor
 
-	// deriveOnUnlock is a list of private keys which needs to be derived
-	// on the next unlock.  This occurs when a public address is derived
-	// while the address manager is locked since it does not have access to
-	// the private extended key (hence nor the underlying private key) in
-	// order to encrypt it.
-	deriveOnUnlock []*unlockDeriveInfo
-
 	// privPassphraseSalt and hashedPrivPassphrase allow for the secure
 	// detection of a correct passphrase on manager unlock when the
 	// manager is already unlocked.  The hash is zeroed each lock.
@@ -304,26 +300,47 @@ type Manager struct {
 	hashedPrivPassphrase [sha512.Size]byte
 }
 
+// Locked returns true if the root manager is locked, and false otherwise.
+func (m *Manager) Locked() bool {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	return m.locked
+}
+
+// WatchOnly returns true if the root manager is in watch only mode, and false
+// otherwise.
+func (m *Manager) WatchOnly() bool {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	return m.watchingOnly
+}
+
 // lock performs a best try effort to remove and zero all secret keys associated
 // with the address manager.
 //
 // This function MUST be called with the manager lock held for writes.
 func (m *Manager) lock() {
-	// Clear all of the account private keys.
-	for _, acctInfo := range m.acctInfo {
-		if acctInfo.acctKeyPriv != nil {
-			acctInfo.acctKeyPriv.Zero()
+	for _, manager := range m.scopedManagers {
+		// Clear all of the account private keys.
+		for _, acctInfo := range manager.acctInfo {
+			if acctInfo.acctKeyPriv != nil {
+				acctInfo.acctKeyPriv.Zero()
+			}
+			acctInfo.acctKeyPriv = nil
 		}
-		acctInfo.acctKeyPriv = nil
 	}
 
 	// Remove clear text private keys and scripts from all address entries.
-	for _, ma := range m.addrs {
-		switch addr := ma.(type) {
-		case *managedAddress:
-			addr.lock()
-		case *scriptAddress:
-			addr.lock()
+	for _, manager := range m.scopedManagers {
+		for _, ma := range manager.addrs {
+			switch addr := ma.(type) {
+			case *managedAddress:
+				addr.lock()
+			case *scriptAddress:
+				addr.lock()
+			}
 		}
 	}
 
@@ -343,21 +360,6 @@ func (m *Manager) lock() {
 	m.locked = true
 }
 
-// zeroSensitivePublicData performs a best try effort to remove and zero all
-// sensitive public data associated with the address manager such as
-// hierarchical deterministic extended public keys and the crypto public keys.
-func (m *Manager) zeroSensitivePublicData() {
-	// Clear all of the account private keys.
-	for _, acctInfo := range m.acctInfo {
-		acctInfo.acctKeyPub.Zero()
-		acctInfo.acctKeyPub = nil
-	}
-
-	// Remove clear text public master and crypto keys from memory.
-	m.cryptoKeyPub.Zero()
-	m.masterKeyPub.Zero()
-}
-
 // Close cleanly shuts down the manager.  It makes a best try effort to remove
 // and zero all private key and sensitive public key material associated with
 // the address manager from memory.
@@ -369,410 +371,369 @@ func (m *Manager) Close() {
 		return
 	}
 
+	for _, manager := range m.scopedManagers {
+		// Zero out the account keys (if any) of all sub key managers.
+		manager.Close()
+	}
+
 	// Attempt to clear private key material from memory.
 	if !m.watchingOnly && !m.locked {
 		m.lock()
 	}
 
-	// Attempt to clear sensitive public key material from memory too.
-	m.zeroSensitivePublicData()
+	// Remove clear text public master and crypto keys from memory.
+	m.cryptoKeyPub.Zero()
+	m.masterKeyPub.Zero()
 
 	m.closed = true
 	return
 }
 
-// keyToManaged returns a new managed address for the provided derived key and
-// its derivation path which consists of the account, branch, and index.
+// NewScopedKeyManager creates a new scoped key manager from the root manager. A
+// scoped key manager is a sub-manager that only has the coin type key of a
+// particular coin type and BIP0043 purpose. This is useful as it enables
+// callers to create an arbitrary BIP0043 like schema with a stand alone
+// manager. Note that a new scoped manager cannot be created if: the wallet is
+// watch only, the manager hasn't been unlocked, or the root key has been.
+// neutered from the database.
 //
-// The passed derivedKey is zeroed after the new address is created.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) keyToManaged(derivedKey *hdkeychain.ExtendedKey,
-	addrType addressType, account, branch, index uint32) (ManagedAddress, error) {
-
-	// Create a new managed address based on the public or private key
-	// depending on whether the passed key is private.  Also, zero the
-	// key after creating the managed address from it.
-	ma, err := newManagedAddressFromExtKey(m, account, derivedKey, addrType)
-	defer derivedKey.Zero()
-	if err != nil {
-		return nil, err
-	}
-	if !derivedKey.IsPrivate() {
-		// Add the managed address to the list of addresses that need
-		// their private keys derived when the address manager is next
-		// unlocked.
-		info := unlockDeriveInfo{
-			managedAddr: ma,
-			branch:      branch,
-			index:       index,
-		}
-		m.deriveOnUnlock = append(m.deriveOnUnlock, &info)
-	}
-	if branch == internalBranch {
-		ma.internal = true
-	}
-
-	return ma, nil
-}
-
-// deriveKey returns either a public or private derived extended key based on
-// the private flag for the given an account info, branch, and index.
-func (m *Manager) deriveKey(acctInfo *accountInfo, branch, index uint32, private bool) (*hdkeychain.ExtendedKey, error) {
-	// Choose the public or private extended key based on whether or not
-	// the private flag was specified.  This, in turn, allows for public or
-	// private child derivation.
-	acctKey := acctInfo.acctKeyPub
-	if private {
-		acctKey = acctInfo.acctKeyPriv
-	}
-
-	// Derive and return the key.
-	branchKey, err := acctKey.Child(branch)
-	if err != nil {
-		str := fmt.Sprintf("failed to derive extended key branch %d",
-			branch)
-		return nil, managerError(ErrKeyChain, str, err)
-	}
-	addressKey, err := branchKey.Child(index)
-	branchKey.Zero() // Zero branch key after it's used.
-	if err != nil {
-		str := fmt.Sprintf("failed to derive child extended key -- "+
-			"branch %d, child %d",
-			branch, index)
-		return nil, managerError(ErrKeyChain, str, err)
-	}
-	return addressKey, nil
-}
-
-// loadAccountInfo attempts to load and cache information about the given
-// account from the database.   This includes what is necessary to derive new
-// keys for it and track the state of the internal and external branches.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) loadAccountInfo(ns walletdb.ReadBucket, account uint32) (*accountInfo, error) {
-	// Return the account info from cache if it's available.
-	if acctInfo, ok := m.acctInfo[account]; ok {
-		return acctInfo, nil
-	}
-
-	// The account is either invalid or just wasn't cached, so attempt to
-	// load the information from the database.
-	rowInterface, err := fetchAccountInfo(ns, account)
-	if err != nil {
-		return nil, maybeConvertDbError(err)
-	}
-
-	// Ensure the account type is a BIP0044 account.
-	row, ok := rowInterface.(*dbBIP0044AccountRow)
-	if !ok {
-		str := fmt.Sprintf("unsupported account type %T", row)
-		err = managerError(ErrDatabase, str, nil)
-	}
-
-	// Use the crypto public key to decrypt the account public extended key.
-	serializedKeyPub, err := m.cryptoKeyPub.Decrypt(row.pubKeyEncrypted)
-	if err != nil {
-		str := fmt.Sprintf("failed to decrypt public key for account %d",
-			account)
-		return nil, managerError(ErrCrypto, str, err)
-	}
-	acctKeyPub, err := hdkeychain.NewKeyFromString(string(serializedKeyPub))
-	if err != nil {
-		str := fmt.Sprintf("failed to create extended public key for "+
-			"account %d", account)
-		return nil, managerError(ErrKeyChain, str, err)
-	}
-
-	// Create the new account info with the known information.  The rest
-	// of the fields are filled out below.
-	acctInfo := &accountInfo{
-		acctName:          row.name,
-		acctKeyEncrypted:  row.privKeyEncrypted,
-		acctKeyPub:        acctKeyPub,
-		nextExternalIndex: row.nextExternalIndex,
-		nextInternalIndex: row.nextInternalIndex,
-	}
-
-	if !m.locked {
-		// Use the crypto private key to decrypt the account private
-		// extended keys.
-		decrypted, err := m.cryptoKeyPriv.Decrypt(acctInfo.acctKeyEncrypted)
-		if err != nil {
-			str := fmt.Sprintf("failed to decrypt private key for "+
-				"account %d", account)
-			return nil, managerError(ErrCrypto, str, err)
-		}
-
-		acctKeyPriv, err := hdkeychain.NewKeyFromString(string(decrypted))
-		if err != nil {
-			str := fmt.Sprintf("failed to create extended private "+
-				"key for account %d", account)
-			return nil, managerError(ErrKeyChain, str, err)
-		}
-		acctInfo.acctKeyPriv = acctKeyPriv
-	}
-
-	// Derive and cache the managed address for the last external address.
-	branch, index := externalBranch, row.nextExternalIndex
-	if index > 0 {
-		index--
-	}
-	lastExtKey, err := m.deriveKey(acctInfo, branch, index, !m.locked)
-	if err != nil {
-		return nil, err
-	}
-	// TODO(roasbeef): default type??
-	lastExtAddr, err := m.keyToManaged(lastExtKey, adtChainWitness,
-		account, branch, index)
-	if err != nil {
-		return nil, err
-	}
-	acctInfo.lastExternalAddr = lastExtAddr
-
-	// Derive and cache the managed address for the last internal address.
-	branch, index = internalBranch, row.nextInternalIndex
-	if index > 0 {
-		index--
-	}
-	lastIntKey, err := m.deriveKey(acctInfo, branch, index, !m.locked)
-	if err != nil {
-		return nil, err
-	}
-	lastIntAddr, err := m.keyToManaged(lastIntKey, adtChainWitness,
-		account, branch, index)
-	if err != nil {
-		return nil, err
-	}
-	acctInfo.lastInternalAddr = lastIntAddr
-
-	// Add it to the cache and return it when everything is successful.
-	m.acctInfo[account] = acctInfo
-	return acctInfo, nil
-}
-
-// AccountProperties returns properties associated with the account, such as the
-// account number, name, and the number of derived and imported keys.
-//
-// TODO: Instead of opening a second read transaction after making a change, and
-// then fetching the account properties with a new read tx, this can be made
-// more performant by simply returning the new account properties during the
-// change.
-func (m *Manager) AccountProperties(ns walletdb.ReadBucket, account uint32) (*AccountProperties, error) {
-	defer m.mtx.RUnlock()
-	m.mtx.RLock()
-
-	props := &AccountProperties{AccountNumber: account}
-
-	// Until keys can be imported into any account, special handling is
-	// required for the imported account.
-	//
-	// loadAccountInfo errors when using it on the imported account since
-	// the accountInfo struct is filled with a BIP0044 account's extended
-	// keys, and the imported accounts has none.
-	//
-	// Since only the imported account allows imports currently, the number
-	// of imported keys for any other account is zero, and since the
-	// imported account cannot contain non-imported keys, the external and
-	// internal key counts for it are zero.
-	if account != ImportedAddrAccount {
-		acctInfo, err := m.loadAccountInfo(ns, account)
-		if err != nil {
-			return nil, err
-		}
-		props.AccountName = acctInfo.acctName
-		props.ExternalKeyCount = acctInfo.nextExternalIndex
-		props.InternalKeyCount = acctInfo.nextInternalIndex
-	} else {
-		props.AccountName = ImportedAddrAccountName // reserved, nonchangable
-
-		// Could be more efficient if this was tracked by the db.
-		var importedKeyCount uint32
-		count := func(interface{}) error {
-			importedKeyCount++
-			return nil
-		}
-		err := forEachAccountAddress(ns, ImportedAddrAccount, count)
-		if err != nil {
-			return nil, err
-		}
-		props.ImportedKeyCount = importedKeyCount
-	}
-
-	return props, nil
-}
-
-// deriveKeyFromPath returns either a public or private derived extended key
-// based on the private flag for the given an account, branch, and index.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) deriveKeyFromPath(ns walletdb.ReadBucket, account, branch, index uint32, private bool) (*hdkeychain.ExtendedKey, error) {
-	// Look up the account key information.
-	acctInfo, err := m.loadAccountInfo(ns, account)
-	if err != nil {
-		return nil, err
-	}
-
-	return m.deriveKey(acctInfo, branch, index, private)
-}
-
-// chainAddressRowToManaged returns a new managed address based on chained
-// address data loaded from the database.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) chainAddressRowToManaged(ns walletdb.ReadBucket, row *dbChainAddressRow) (ManagedAddress, error) {
-	addressKey, err := m.deriveKeyFromPath(ns, row.account, row.branch,
-		row.index, !m.locked)
-	if err != nil {
-		return nil, err
-	}
-
-	return m.keyToManaged(addressKey, row.addrType, row.account, row.branch, row.index)
-}
-
-// importedAddressRowToManaged returns a new managed address based on imported
-// address data loaded from the database.
-func (m *Manager) importedAddressRowToManaged(row *dbImportedAddressRow) (ManagedAddress, error) {
-	// Use the crypto public key to decrypt the imported public key.
-	pubBytes, err := m.cryptoKeyPub.Decrypt(row.encryptedPubKey)
-	if err != nil {
-		str := "failed to decrypt public key for imported address"
-		return nil, managerError(ErrCrypto, str, err)
-	}
-
-	pubKey, err := btcec.ParsePubKey(pubBytes, btcec.S256())
-	if err != nil {
-		str := "invalid public key for imported address"
-		return nil, managerError(ErrCrypto, str, err)
-	}
-
-	compressed := len(pubBytes) == btcec.PubKeyBytesLenCompressed
-	ma, err := newManagedAddressWithoutPrivKey(m, row.account, pubKey,
-		compressed, row.addrType)
-	if err != nil {
-		return nil, err
-	}
-	ma.privKeyEncrypted = row.encryptedPrivKey
-	ma.imported = true
-
-	return ma, nil
-}
-
-// scriptAddressRowToManaged returns a new managed address based on script
-// address data loaded from the database.
-func (m *Manager) scriptAddressRowToManaged(row *dbScriptAddressRow) (ManagedAddress, error) {
-	// Use the crypto public key to decrypt the imported script hash.
-	scriptHash, err := m.cryptoKeyPub.Decrypt(row.encryptedHash)
-	if err != nil {
-		str := "failed to decrypt imported script hash"
-		return nil, managerError(ErrCrypto, str, err)
-	}
-
-	return newScriptAddress(m, row.account, scriptHash, row.encryptedScript)
-}
-
-// rowInterfaceToManaged returns a new managed address based on the given
-// address data loaded from the database.  It will automatically select the
-// appropriate type.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) rowInterfaceToManaged(ns walletdb.ReadBucket, rowInterface interface{}) (ManagedAddress, error) {
-	switch row := rowInterface.(type) {
-	case *dbChainAddressRow:
-		return m.chainAddressRowToManaged(ns, row)
-
-	case *dbImportedAddressRow:
-		return m.importedAddressRowToManaged(row)
-
-	case *dbScriptAddressRow:
-		return m.scriptAddressRowToManaged(row)
-	}
-
-	str := fmt.Sprintf("unsupported address type %T", rowInterface)
-	return nil, managerError(ErrDatabase, str, nil)
-}
-
-// loadAndCacheAddress attempts to load the passed address from the database and
-// caches the associated managed address.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) loadAndCacheAddress(ns walletdb.ReadBucket, address btcutil.Address) (ManagedAddress, error) {
-	// Attempt to load the raw address information from the database.
-	rowInterface, err := fetchAddress(ns, address.ScriptAddress())
-	if err != nil {
-		if merr, ok := err.(*ManagerError); ok {
-			desc := fmt.Sprintf("failed to fetch address '%s': %v",
-				address.ScriptAddress(), merr.Description)
-			merr.Description = desc
-			return nil, merr
-		}
-		return nil, maybeConvertDbError(err)
-	}
-
-	// Create a new managed address for the specific type of address based
-	// on type.
-	managedAddr, err := m.rowInterfaceToManaged(ns, rowInterface)
-	if err != nil {
-		return nil, err
-	}
-
-	// Cache and return the new managed address.
-	m.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
-	return managedAddr, nil
-}
-
-// Address returns a managed address given the passed address if it is known
-// to the address manager.  A managed address differs from the passed address
-// in that it also potentially contains extra information needed to sign
-// transactions such as the associated private key for pay-to-pubkey and
-// pay-to-pubkey-hash addresses and the script associated with
-// pay-to-script-hash addresses.
-func (m *Manager) Address(ns walletdb.ReadBucket, address btcutil.Address) (ManagedAddress, error) {
-	// ScriptAddress will only return a script hash if we're
-	// accessing an address that is either PKH or SH. In
-	// the event we're passed a PK address, convert the
-	// PK to PKH address so that we can access it from
-	// the addrs map and database.
-	if pka, ok := address.(*btcutil.AddressPubKey); ok {
-		address = pka.AddressPubKeyHash()
-	}
-
-	// TODO(roasbeef): also need to distinguish p2wkh from p2pkh
-
-	// Return the address from cache if it's available.
-	//
-	// NOTE: Not using a defer on the lock here since a write lock is
-	// needed if the lookup fails.
-	m.mtx.RLock()
-	if ma, ok := m.addrs[addrKey(address.ScriptAddress())]; ok {
-		m.mtx.RUnlock()
-		return ma, nil
-	}
-	m.mtx.RUnlock()
+// TODO(roasbeef): addrtype of raw key means it'll look in scripts to possibly
+// mark as gucci?
+func (m *Manager) NewScopedKeyManager(ns walletdb.ReadWriteBucket, scope KeyScope,
+	addrSchema ScopeAddrSchema) (*ScopedKeyManager, error) {
 
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	// Attempt to load the address from the database.
-	return m.loadAndCacheAddress(ns, address)
+	// If the manager is locked, then we can't create a new scoped manager.
+	if m.locked {
+		return nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	// Now that we know the manager is unlocked, we'll need to fetch the
+	// root master HD private key. This is required as we'll be attempting
+	// the following derivation: m/purpose'/cointype'
+	//
+	// Note that the path to the coin type is requires hardened derivation,
+	// therefore this can only be done if the wallet's root key hasn't been
+	// neutered.
+	masterRootPrivEnc, _, err := fetchMasterHDKeys(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the master root private key isn't found within the database, but
+	// we need to bail here as we can't create the cointype key without the
+	// master root private key.
+	if masterRootPrivEnc == nil {
+		return nil, managerError(ErrWatchingOnly, "", nil)
+	}
+
+	// Before we can derive any new scoped managers using this key, we'll
+	// need to fully decrypt it.
+	serializedMasterRootPriv, err := m.cryptoKeyPriv.Decrypt(masterRootPrivEnc)
+	if err != nil {
+		str := fmt.Sprintf("failed to decrypt master root serialized private key")
+		return nil, managerError(ErrLocked, str, err)
+	}
+
+	// Now that we know the root priv is within the database, we'll decode
+	// it into a usable object.
+	rootPriv, err := hdkeychain.NewKeyFromString(
+		string(serializedMasterRootPriv),
+	)
+	zero.Bytes(serializedMasterRootPriv)
+	if err != nil {
+		str := fmt.Sprintf("failed to create master extended private key")
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	// Now that we have the root private key, we'll fetch the scope bucket
+	// so we can create the proper internal name spaces.
+	scopeBucket := ns.NestedReadWriteBucket(scopeBucketName)
+
+	// Now that we know it's possible to actually create a new scoped
+	// manager, we'll carve out its bucket space within the database.
+	if err := createScopedManagerNS(scopeBucket, &scope); err != nil {
+		return nil, err
+	}
+
+	// With the database state created, we'll now write down the address
+	// schema of this particular scope type.
+	scopeSchemas := ns.NestedReadWriteBucket(scopeSchemaBucketName)
+	if scopeSchemas == nil {
+		str := "scope schema bucket not found"
+		return nil, managerError(ErrDatabase, str, nil)
+	}
+	scopeKey := scopeToBytes(&scope)
+	schemaBytes := scopeSchemaToBytes(&addrSchema)
+	err = scopeSchemas.Put(scopeKey[:], schemaBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// With the database state created, we'll now derive the cointype key
+	// using the master HD private key, then encrypt it along with the
+	// first account using our crypto keys.
+	err = createManagerKeyScope(
+		ns, scope, rootPriv, m.cryptoKeyPub, m.cryptoKeyPriv,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Finally, we'll register this new scoped manager with the root
+	// manager.
+	m.scopedManagers[scope] = &ScopedKeyManager{
+		scope:       scope,
+		addrSchema:  addrSchema,
+		rootManager: m,
+		addrs:       make(map[addrKey]ManagedAddress),
+		acctInfo:    make(map[uint32]*accountInfo),
+	}
+	m.externalAddrSchemas[addrSchema.ExternalAddrType] = append(
+		m.externalAddrSchemas[addrSchema.ExternalAddrType], scope,
+	)
+	m.internalAddrSchemas[addrSchema.InternalAddrType] = append(
+		m.internalAddrSchemas[addrSchema.InternalAddrType], scope,
+	)
+
+	return m.scopedManagers[scope], nil
 }
 
-// AddrAccount returns the account to which the given address belongs.
-func (m *Manager) AddrAccount(ns walletdb.ReadBucket, address btcutil.Address) (uint32, error) {
-	account, err := fetchAddrAccount(ns, address.ScriptAddress())
-	if err != nil {
-		return 0, maybeConvertDbError(err)
+// FetchScopedKeyManager attempts to fetch an active scoped manager according to
+// its registered scope. If the manger is found, then a nil error is returned
+// along with the active scoped manager. Otherwise, a nil manager and a non-nil
+// error will be returned.
+func (m *Manager) FetchScopedKeyManager(scope KeyScope) (*ScopedKeyManager, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	sm, ok := m.scopedManagers[scope]
+	if !ok {
+		str := fmt.Sprintf("scope %v not found", scope)
+		return nil, managerError(ErrScopeNotFound, str, nil)
 	}
-	return account, nil
+
+	return sm, nil
+}
+
+// ActiveScopedKeyManagers returns a slice of all the active scoped key
+// managers currently known by the root key manager.
+func (m *Manager) ActiveScopedKeyManagers() []*ScopedKeyManager {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	var scopedManagers []*ScopedKeyManager
+	for _, smgr := range m.scopedManagers {
+		scopedManagers = append(scopedManagers, smgr)
+	}
+
+	return scopedManagers
+}
+
+// ScopesForExternalAddrTypes returns the set of key scopes that are able to
+// produce the target address type as external addresses.
+func (m *Manager) ScopesForExternalAddrType(addrType AddressType) []KeyScope {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	scopes, _ := m.externalAddrSchemas[addrType]
+	return scopes
+}
+
+// ScopesForInternalAddrTypes returns the set of key scopes that are able to
+// produce the target address type as internal addresses.
+func (m *Manager) ScopesForInternalAddrTypes(addrType AddressType) []KeyScope {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	scopes, _ := m.internalAddrSchemas[addrType]
+	return scopes
+}
+
+// NeuterRootKey is a special method that should be used once a caller is
+// *certain* that no further scoped managers are to be created. This method
+// will *delete* the encrypted master HD root private key from the database.
+func (m *Manager) NeuterRootKey(ns walletdb.ReadWriteBucket) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	// First, we'll fetch the current master HD keys from the database.
+	masterRootPrivEnc, _, err := fetchMasterHDKeys(ns)
+	if err != nil {
+		return err
+	}
+
+	// If the root master private key is already nil, then we'll return a
+	// nil error here as the root key has already been permanently
+	// neutered.
+	if masterRootPrivEnc == nil {
+		return nil
+	}
+	zero.Bytes(masterRootPrivEnc)
+
+	// Otherwise, we'll neuter the root key permanently by deleting the
+	// encrypted master HD key from the database.
+	return ns.NestedReadWriteBucket(mainBucketName).Delete(masterHDPrivName)
+}
+
+// Address returns a managed address given the passed address if it is known to
+// the address manager. A managed address differs from the passed address in
+// that it also potentially contains extra information needed to sign
+// transactions such as the associated private key for pay-to-pubkey and
+// pay-to-pubkey-hash addresses and the script associated with
+// pay-to-script-hash addresses.
+func (m *Manager) Address(ns walletdb.ReadBucket,
+	address btcutil.Address) (ManagedAddress, error) {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	// We'll iterate through each of the known scoped managers, and see if
+	// any of them now of the target address.
+	for _, scopedMgr := range m.scopedManagers {
+		addr, err := scopedMgr.Address(ns, address)
+		if err != nil {
+			continue
+		}
+
+		return addr, nil
+	}
+
+	// If the address wasn't known to any of the scoped managers, then
+	// we'll return an error.
+	str := fmt.Sprintf("unable to find key for addr %v", address)
+	return nil, managerError(ErrAddressNotFound, str, nil)
+}
+
+// MarkUsed updates the used flag for the provided address.
+func (m *Manager) MarkUsed(ns walletdb.ReadWriteBucket, address btcutil.Address) error {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	// Run through all the known scoped managers, and attempt to mark the
+	// address as used for each one.
+
+	// First, we'll figure out which scoped manager this address belong to.
+	for _, scopedMgr := range m.scopedManagers {
+		if _, err := scopedMgr.Address(ns, address); err != nil {
+			continue
+		}
+
+		// We've found the manager that this address belongs to, so we
+		// can mark the address as used and return.
+		return scopedMgr.MarkUsed(ns, address)
+	}
+
+	// If we get to this point, then we weren't able to find the address in
+	// any of the managers, so we'll exit with an error.
+	str := fmt.Sprintf("unable to find key for addr %v", address)
+	return managerError(ErrAddressNotFound, str, nil)
+}
+
+// AddrAccount returns the account to which the given address belongs. We also
+// return the scoped manager that owns the addr+account combo.
+func (m *Manager) AddrAccount(ns walletdb.ReadBucket,
+	address btcutil.Address) (*ScopedKeyManager, uint32, error) {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedMgr := range m.scopedManagers {
+		if _, err := scopedMgr.Address(ns, address); err != nil {
+			continue
+		}
+
+		// We've found the manager that this address belongs to, so we
+		// can retrieve the address' account along with the manager
+		// that the addr belongs to.
+		accNo, err := scopedMgr.AddrAccount(ns, address)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return scopedMgr, accNo, err
+	}
+
+	// If we get to this point, then we weren't able to find the address in
+	// any of the managers, so we'll exit with an error.
+	str := fmt.Sprintf("unable to find key for addr %v", address)
+	return nil, 0, managerError(ErrAddressNotFound, str, nil)
+}
+
+// ForEachActiveAccountAddress calls the given function with each active
+// address of the given account stored in the manager, across all active
+// scopes, breaking early on error.
+//
+// TODO(tuxcanfly): actually return only active addresses
+func (m *Manager) ForEachActiveAccountAddress(ns walletdb.ReadBucket,
+	account uint32, fn func(maddr ManagedAddress) error) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedMgr := range m.scopedManagers {
+		err := scopedMgr.ForEachActiveAccountAddress(ns, account, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachActiveAddress calls the given function with each active address
+// stored in the manager, breaking early on error.
+func (m *Manager) ForEachActiveAddress(ns walletdb.ReadBucket, fn func(addr btcutil.Address) error) error {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	for _, scopedMgr := range m.scopedManagers {
+		err := scopedMgr.ForEachActiveAddress(ns, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachAccountAddress calls the given function with each address of
+// the given account stored in the manager, breaking early on error.
+func (m *Manager) ForEachAccountAddress(ns walletdb.ReadBucket, account uint32,
+	fn func(maddr ManagedAddress) error) error {
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	for _, scopedMgr := range m.scopedManagers {
+		err := scopedMgr.ForEachAccountAddress(ns, account, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ChainParams returns the chain parameters for this address manager.
+func (m *Manager) ChainParams() *chaincfg.Params {
+	// NOTE: No need for mutex here since the net field does not change
+	// after the manager instance is created.
+
+	return m.chainParams
 }
 
 // ChangePassphrase changes either the public or private passphrase to the
-// provided value depending on the private flag.  In order to change the private
-// password, the address manager must not be watching-only.  The new passphrase
-// keys are derived using the scrypt parameters in the options, so changing the
-// passphrase may be used to bump the computational difficulty needed to brute
-// force the passphrase.
-func (m *Manager) ChangePassphrase(ns walletdb.ReadWriteBucket, oldPassphrase, newPassphrase []byte, private bool, config *ScryptOptions) error {
+// provided value depending on the private flag.  In order to change the
+// private password, the address manager must not be watching-only.  The new
+// passphrase keys are derived using the scrypt parameters in the options, so
+// changing the passphrase may be used to bump the computational difficulty
+// needed to brute force the passphrase.
+func (m *Manager) ChangePassphrase(ns walletdb.ReadWriteBucket, oldPassphrase,
+	newPassphrase []byte, private bool, config *ScryptOptions) error {
+
 	// No private passphrase to change for a watching-only address manager.
 	if private && m.watchingOnly {
 		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
@@ -846,8 +807,8 @@ func (m *Manager) ChangePassphrase(ns walletdb.ReadWriteBucket, oldPassphrase, n
 			return managerError(ErrCrypto, str, err)
 		}
 
-		// Re-encrypt the crypto script key using the new master private
-		// key.
+		// Re-encrypt the crypto script key using the new master
+		// private key.
 		decScript, err := secretKey.Decrypt(m.cryptoKeyScriptEncrypted)
 		if err != nil {
 			str := "failed to decrypt crypto script key"
@@ -874,7 +835,7 @@ func (m *Manager) ChangePassphrase(ns walletdb.ReadWriteBucket, oldPassphrase, n
 			zero.Bytes(saltedPassphrase)
 		}
 
-		// Save the new keys and params to the the db in a single
+		// Save the new keys and params to the db in a single
 		// transaction.
 		err = putCryptoKeys(ns, nil, encPriv, encScript)
 		if err != nil {
@@ -943,10 +904,11 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 		return nil
 	}
 
-	// Remove all private key material and mark the new database as watching
-	// only.
-	err := deletePrivateKeys(ns)
-	if err != nil {
+	var err error
+
+	// Remove all private key material and mark the new database as
+	// watching only.
+	if err := deletePrivateKeys(ns); err != nil {
 		return maybeConvertDbError(err)
 	}
 
@@ -967,21 +929,25 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 	// material is no longer needed.
 
 	// Clear and remove all of the encrypted acount private keys.
-	for _, acctInfo := range m.acctInfo {
-		zero.Bytes(acctInfo.acctKeyEncrypted)
-		acctInfo.acctKeyEncrypted = nil
+	for _, manager := range m.scopedManagers {
+		for _, acctInfo := range manager.acctInfo {
+			zero.Bytes(acctInfo.acctKeyEncrypted)
+			acctInfo.acctKeyEncrypted = nil
+		}
 	}
 
 	// Clear and remove encrypted private keys and encrypted scripts from
 	// all address entries.
-	for _, ma := range m.addrs {
-		switch addr := ma.(type) {
-		case *managedAddress:
-			zero.Bytes(addr.privKeyEncrypted)
-			addr.privKeyEncrypted = nil
-		case *scriptAddress:
-			zero.Bytes(addr.scriptEncrypted)
-			addr.scriptEncrypted = nil
+	for _, manager := range m.scopedManagers {
+		for _, ma := range manager.addrs {
+			switch addr := ma.(type) {
+			case *managedAddress:
+				zero.Bytes(addr.privKeyEncrypted)
+				addr.privKeyEncrypted = nil
+			case *scriptAddress:
+				zero.Bytes(addr.scriptEncrypted)
+				addr.scriptEncrypted = nil
+			}
 		}
 	}
 
@@ -1002,233 +968,6 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 	m.watchingOnly = true
 	return nil
 
-}
-
-// existsAddress returns whether or not the passed address is known to the
-// address manager.
-//
-// This function MUST be called with the manager lock held for reads.
-func (m *Manager) existsAddress(ns walletdb.ReadBucket, addressID []byte) bool {
-	// Check the in-memory map first since it's faster than a db access.
-	if _, ok := m.addrs[addrKey(addressID)]; ok {
-		return true
-	}
-
-	// Check the database if not already found above.
-	return existsAddress(ns, addressID)
-}
-
-// ImportPrivateKey imports a WIF private key into the address manager.  The
-// imported address is created using either a compressed or uncompressed
-// serialized public key, depending on the CompressPubKey bool of the WIF.
-//
-// All imported addresses will be part of the account defined by the
-// ImportedAddrAccount constant.
-//
-// NOTE: When the address manager is watching-only, the private key itself will
-// not be stored or available since it is private data.  Instead, only the
-// public key will be stored.  This means it is paramount the private key is
-// kept elsewhere as the watching-only address manager will NOT ever have access
-// to it.
-//
-// This function will return an error if the address manager is locked and not
-// watching-only, or not for the same network as the key trying to be imported.
-// It will also return an error if the address already exists.  Any other errors
-// returned are generally unexpected.
-func (m *Manager) ImportPrivateKey(ns walletdb.ReadWriteBucket, wif *btcutil.WIF, bs *BlockStamp) (ManagedPubKeyAddress, error) {
-	// Ensure the address is intended for network the address manager is
-	// associated with.
-	if !wif.IsForNet(m.chainParams) {
-		str := fmt.Sprintf("private key is not for the same network the "+
-			"address manager is configured for (%s)",
-			m.chainParams.Name)
-		return nil, managerError(ErrWrongNet, str, nil)
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	// The manager must be unlocked to encrypt the imported private key.
-	if m.locked && !m.watchingOnly {
-		return nil, managerError(ErrLocked, errLocked, nil)
-	}
-
-	// Prevent duplicates.
-	serializedPubKey := wif.SerializePubKey()
-	pubKeyHash := btcutil.Hash160(serializedPubKey)
-	alreadyExists := m.existsAddress(ns, pubKeyHash)
-	if alreadyExists {
-		str := fmt.Sprintf("address for public key %x already exists",
-			serializedPubKey)
-		return nil, managerError(ErrDuplicateAddress, str, nil)
-	}
-
-	// Encrypt public key.
-	encryptedPubKey, err := m.cryptoKeyPub.Encrypt(serializedPubKey)
-	if err != nil {
-		str := fmt.Sprintf("failed to encrypt public key for %x",
-			serializedPubKey)
-		return nil, managerError(ErrCrypto, str, err)
-	}
-
-	// Encrypt the private key when not a watching-only address manager.
-	var encryptedPrivKey []byte
-	if !m.watchingOnly {
-		privKeyBytes := wif.PrivKey.Serialize()
-		encryptedPrivKey, err = m.cryptoKeyPriv.Encrypt(privKeyBytes)
-		zero.Bytes(privKeyBytes)
-		if err != nil {
-			str := fmt.Sprintf("failed to encrypt private key for %x",
-				serializedPubKey)
-			return nil, managerError(ErrCrypto, str, err)
-		}
-	}
-
-	// The start block needs to be updated when the newly imported address
-	// is before the current one.
-	updateStartBlock := bs.Height < m.syncState.startBlock.Height
-
-	// Save the new imported address to the db and update start block (if
-	// needed) in a single transaction.
-	err = putImportedAddress(ns, pubKeyHash, ImportedAddrAccount, ssNone,
-		encryptedPubKey, encryptedPrivKey)
-	if err != nil {
-		return nil, err
-	}
-
-	if updateStartBlock {
-		err := putStartBlock(ns, bs)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Now that the database has been updated, update the start block in
-	// memory too if needed.
-	if updateStartBlock {
-		m.syncState.startBlock = *bs
-	}
-
-	// Create a new managed address based on the imported address.
-	var managedAddr *managedAddress
-	// TODO(roasbeef): default type? need to watch for all
-	if !m.watchingOnly {
-		managedAddr, err = newManagedAddress(m, ImportedAddrAccount,
-			wif.PrivKey, wif.CompressPubKey, adtChain)
-	} else {
-		pubKey := (*btcec.PublicKey)(&wif.PrivKey.PublicKey)
-		managedAddr, err = newManagedAddressWithoutPrivKey(m,
-			ImportedAddrAccount, pubKey, wif.CompressPubKey,
-			adtChain)
-	}
-	if err != nil {
-		return nil, err
-	}
-	managedAddr.imported = true
-
-	// Add the new managed address to the cache of recent addresses and
-	// return it.
-	m.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
-	return managedAddr, nil
-}
-
-// ImportScript imports a user-provided script into the address manager.  The
-// imported script will act as a pay-to-script-hash address.
-//
-// All imported script addresses will be part of the account defined by the
-// ImportedAddrAccount constant.
-//
-// When the address manager is watching-only, the script itself will not be
-// stored or available since it is considered private data.
-//
-// This function will return an error if the address manager is locked and not
-// watching-only, or the address already exists.  Any other errors returned are
-// generally unexpected.
-func (m *Manager) ImportScript(ns walletdb.ReadWriteBucket, script []byte, bs *BlockStamp) (ManagedScriptAddress, error) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	// The manager must be unlocked to encrypt the imported script.
-	if m.locked && !m.watchingOnly {
-		return nil, managerError(ErrLocked, errLocked, nil)
-	}
-
-	// Prevent duplicates.
-	scriptHash := btcutil.Hash160(script)
-	alreadyExists := m.existsAddress(ns, scriptHash)
-	if alreadyExists {
-		str := fmt.Sprintf("address for script hash %x already exists",
-			scriptHash)
-		return nil, managerError(ErrDuplicateAddress, str, nil)
-	}
-
-	// Encrypt the script hash using the crypto public key so it is
-	// accessible when the address manager is locked or watching-only.
-	encryptedHash, err := m.cryptoKeyPub.Encrypt(scriptHash)
-	if err != nil {
-		str := fmt.Sprintf("failed to encrypt script hash %x",
-			scriptHash)
-		return nil, managerError(ErrCrypto, str, err)
-	}
-
-	// Encrypt the script for storage in database using the crypto script
-	// key when not a watching-only address manager.
-	var encryptedScript []byte
-	if !m.watchingOnly {
-		encryptedScript, err = m.cryptoKeyScript.Encrypt(script)
-		if err != nil {
-			str := fmt.Sprintf("failed to encrypt script for %x",
-				scriptHash)
-			return nil, managerError(ErrCrypto, str, err)
-		}
-	}
-
-	// The start block needs to be updated when the newly imported address
-	// is before the current one.
-	updateStartBlock := false
-	if bs.Height < m.syncState.startBlock.Height {
-		updateStartBlock = true
-	}
-
-	// Save the new imported address to the db and update start block (if
-	// needed) in a single transaction.
-	err = putScriptAddress(ns, scriptHash, ImportedAddrAccount,
-		ssNone, encryptedHash, encryptedScript)
-	if err != nil {
-		return nil, maybeConvertDbError(err)
-	}
-
-	if updateStartBlock {
-		err := putStartBlock(ns, bs)
-		if err != nil {
-			return nil, maybeConvertDbError(err)
-		}
-	}
-
-	// Now that the database has been updated, update the start block in
-	// memory too if needed.
-	if updateStartBlock {
-		m.syncState.startBlock = *bs
-	}
-
-	// Create a new managed address based on the imported script.  Also,
-	// when not a watching-only address manager, make a copy of the script
-	// since it will be cleared on lock and the script the caller passed
-	// should not be cleared out from under the caller.
-	scriptAddr, err := newScriptAddress(m, ImportedAddrAccount, scriptHash,
-		encryptedScript)
-	if err != nil {
-		return nil, err
-	}
-	if !m.watchingOnly {
-		scriptAddr.scriptCT = make([]byte, len(script))
-		copy(scriptAddr.scriptCT, script)
-	}
-
-	// Add the new managed address to the cache of recent addresses and
-	// return it.
-	m.addrs[addrKey(scriptHash)] = scriptAddr
-	return scriptAddr, nil
 }
 
 // IsLocked returns whether or not the address managed is locked.  When it is
@@ -1262,23 +1001,6 @@ func (m *Manager) Lock() error {
 
 	m.lock()
 	return nil
-}
-
-// lookupAccount loads account number stored in the manager for the given
-// account name
-//
-// This function MUST be called with the manager lock held for reads.
-func (m *Manager) lookupAccount(ns walletdb.ReadBucket, name string) (uint32, error) {
-	return fetchAccountByName(ns, name)
-}
-
-// LookupAccount loads account number stored in the manager for the given
-// account name
-func (m *Manager) LookupAccount(ns walletdb.ReadBucket, name string) (uint32, error) {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	return m.lookupAccount(ns, name)
 }
 
 // Unlock derives the master private key from the specified passphrase.  An
@@ -1337,63 +1059,66 @@ func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 
 	// Use the crypto private key to decrypt all of the account private
 	// extended keys.
-	for account, acctInfo := range m.acctInfo {
-		decrypted, err := m.cryptoKeyPriv.Decrypt(acctInfo.acctKeyEncrypted)
-		if err != nil {
-			m.lock()
-			str := fmt.Sprintf("failed to decrypt account %d "+
-				"private key", account)
-			return managerError(ErrCrypto, str, err)
+	for _, manager := range m.scopedManagers {
+		for account, acctInfo := range manager.acctInfo {
+			decrypted, err := m.cryptoKeyPriv.Decrypt(acctInfo.acctKeyEncrypted)
+			if err != nil {
+				m.lock()
+				str := fmt.Sprintf("failed to decrypt account %d "+
+					"private key", account)
+				return managerError(ErrCrypto, str, err)
+			}
+
+			acctKeyPriv, err := hdkeychain.NewKeyFromString(string(decrypted))
+			zero.Bytes(decrypted)
+			if err != nil {
+				m.lock()
+				str := fmt.Sprintf("failed to regenerate account %d "+
+					"extended key", account)
+				return managerError(ErrKeyChain, str, err)
+			}
+			acctInfo.acctKeyPriv = acctKeyPriv
 		}
 
-		acctKeyPriv, err := hdkeychain.NewKeyFromString(string(decrypted))
-		zero.Bytes(decrypted)
-		if err != nil {
-			m.lock()
-			str := fmt.Sprintf("failed to regenerate account %d "+
-				"extended key", account)
-			return managerError(ErrKeyChain, str, err)
+		// We'll also derive any private keys that are pending due to
+		// them being created while the address manager was locked.
+		for _, info := range manager.deriveOnUnlock {
+			addressKey, err := manager.deriveKeyFromPath(
+				ns, info.managedAddr.Account(), info.branch,
+				info.index, true,
+			)
+			if err != nil {
+				m.lock()
+				return err
+			}
+
+			// It's ok to ignore the error here since it can only
+			// fail if the extended key is not private, however it
+			// was just derived as a private key.
+			privKey, _ := addressKey.ECPrivKey()
+			addressKey.Zero()
+
+			privKeyBytes := privKey.Serialize()
+			privKeyEncrypted, err := m.cryptoKeyPriv.Encrypt(privKeyBytes)
+			zero.BigInt(privKey.D)
+			if err != nil {
+				m.lock()
+				str := fmt.Sprintf("failed to encrypt private key for "+
+					"address %s", info.managedAddr.Address())
+				return managerError(ErrCrypto, str, err)
+			}
+
+			switch a := info.managedAddr.(type) {
+			case *managedAddress:
+				a.privKeyEncrypted = privKeyEncrypted
+				a.privKeyCT = privKeyBytes
+			case *scriptAddress:
+			}
+
+			// Avoid re-deriving this key on subsequent unlocks.
+			manager.deriveOnUnlock[0] = nil
+			manager.deriveOnUnlock = manager.deriveOnUnlock[1:]
 		}
-		acctInfo.acctKeyPriv = acctKeyPriv
-	}
-
-	// Derive any private keys that are pending due to them being created
-	// while the address manager was locked.
-	for _, info := range m.deriveOnUnlock {
-		addressKey, err := m.deriveKeyFromPath(ns, info.managedAddr.Account(),
-			info.branch, info.index, true)
-		if err != nil {
-			m.lock()
-			return err
-		}
-
-		// It's ok to ignore the error here since it can only fail if
-		// the extended key is not private, however it was just derived
-		// as a private key.
-		privKey, _ := addressKey.ECPrivKey()
-		addressKey.Zero()
-
-		privKeyBytes := privKey.Serialize()
-		privKeyEncrypted, err := m.cryptoKeyPriv.Encrypt(privKeyBytes)
-		zero.BigInt(privKey.D)
-		if err != nil {
-			m.lock()
-			str := fmt.Sprintf("failed to encrypt private key for "+
-				"address %s", info.managedAddr.Address())
-			return managerError(ErrCrypto, str, err)
-		}
-
-		// TODO(roasbeef): don't need to do anythign further?
-		switch a := info.managedAddr.(type) {
-		case *managedAddress:
-			a.privKeyEncrypted = privKeyEncrypted
-			a.privKeyCT = privKeyBytes
-		case *scriptAddress:
-		}
-
-		// Avoid re-deriving this key on subsequent unlocks.
-		m.deriveOnUnlock[0] = nil
-		m.deriveOnUnlock = m.deriveOnUnlock[1:]
 	}
 
 	m.locked = false
@@ -1401,290 +1126,6 @@ func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 	m.hashedPrivPassphrase = sha512.Sum512(saltedPassphrase)
 	zero.Bytes(saltedPassphrase)
 	return nil
-}
-
-// fetchUsed returns true if the provided address id was flagged used.
-func (m *Manager) fetchUsed(ns walletdb.ReadBucket, addressID []byte) bool {
-	return fetchAddressUsed(ns, addressID)
-}
-
-// MarkUsed updates the used flag for the provided address.
-func (m *Manager) MarkUsed(ns walletdb.ReadWriteBucket, address btcutil.Address) error {
-	addressID := address.ScriptAddress()
-	err := markAddressUsed(ns, addressID)
-	if err != nil {
-		return maybeConvertDbError(err)
-	}
-	// Clear caches which might have stale entries for used addresses
-	m.mtx.Lock()
-	delete(m.addrs, addrKey(addressID))
-	m.mtx.Unlock()
-	return nil
-}
-
-// ChainParams returns the chain parameters for this address manager.
-func (m *Manager) ChainParams() *chaincfg.Params {
-	// NOTE: No need for mutex here since the net field does not change
-	// after the manager instance is created.
-
-	return m.chainParams
-}
-
-// nextAddresses returns the specified number of next chained address from the
-// branch indicated by the internal flag.
-//
-// This function MUST be called with the manager lock held for writes.
-func (m *Manager) nextAddresses(ns walletdb.ReadWriteBucket, account uint32, numAddresses uint32, internal bool,
-	addrType addressType) ([]ManagedAddress, error) {
-	// The next address can only be generated for accounts that have already
-	// been created.
-	acctInfo, err := m.loadAccountInfo(ns, account)
-	if err != nil {
-		return nil, err
-	}
-
-	// Choose the account key to used based on whether the address manager
-	// is locked.
-	acctKey := acctInfo.acctKeyPub
-	if !m.locked {
-		acctKey = acctInfo.acctKeyPriv
-	}
-
-	// Choose the branch key and index depending on whether or not this
-	// is an internal address.
-	branchNum, nextIndex := externalBranch, acctInfo.nextExternalIndex
-	if internal {
-		branchNum = internalBranch
-		nextIndex = acctInfo.nextInternalIndex
-	}
-
-	// Ensure the requested number of addresses doesn't exceed the maximum
-	// allowed for this account.
-	if numAddresses > MaxAddressesPerAccount || nextIndex+numAddresses >
-		MaxAddressesPerAccount {
-		str := fmt.Sprintf("%d new addresses would exceed the maximum "+
-			"allowed number of addresses per account of %d",
-			numAddresses, MaxAddressesPerAccount)
-		return nil, managerError(ErrTooManyAddresses, str, nil)
-	}
-
-	// Derive the appropriate branch key and ensure it is zeroed when done.
-	branchKey, err := acctKey.Child(branchNum)
-	if err != nil {
-		str := fmt.Sprintf("failed to derive extended key branch %d",
-			branchNum)
-		return nil, managerError(ErrKeyChain, str, err)
-	}
-	defer branchKey.Zero() // Ensure branch key is zeroed when done.
-
-	// Create the requested number of addresses and keep track of the index
-	// with each one.
-	addressInfo := make([]*unlockDeriveInfo, 0, numAddresses)
-	for i := uint32(0); i < numAddresses; i++ {
-		// There is an extremely small chance that a particular child is
-		// invalid, so use a loop to derive the next valid child.
-		var nextKey *hdkeychain.ExtendedKey
-		for {
-			// Derive the next child in the external chain branch.
-			key, err := branchKey.Child(nextIndex)
-			if err != nil {
-				// When this particular child is invalid, skip to the
-				// next index.
-				if err == hdkeychain.ErrInvalidChild {
-					nextIndex++
-					continue
-				}
-
-				str := fmt.Sprintf("failed to generate child %d",
-					nextIndex)
-				return nil, managerError(ErrKeyChain, str, err)
-			}
-			key.SetNet(m.chainParams)
-
-			nextIndex++
-			nextKey = key
-			break
-		}
-
-		// Create a new managed address based on the public or private
-		// key depending on whether the generated key is private.  Also,
-		// zero the next key after creating the managed address from it.
-		addr, err := newManagedAddressFromExtKey(m, account, nextKey, addrType)
-		if err != nil {
-			return nil, err
-		}
-		if internal {
-			addr.internal = true
-		}
-		managedAddr := addr
-		nextKey.Zero()
-
-		info := unlockDeriveInfo{
-			managedAddr: managedAddr,
-			branch:      branchNum,
-			index:       nextIndex - 1,
-		}
-		addressInfo = append(addressInfo, &info)
-	}
-
-	// Now that all addresses have been successfully generated, update the
-	// database in a single transaction.
-	for _, info := range addressInfo {
-		ma := info.managedAddr
-		addressID := ma.Address().ScriptAddress()
-
-		switch a := ma.(type) {
-		case *managedAddress:
-			err := putChainedAddress(ns, addressID, account, ssFull,
-				info.branch, info.index, addrType)
-			if err != nil {
-				return nil, maybeConvertDbError(err)
-			}
-		case *scriptAddress: // TODO(roasbeef): no longer needed?
-			encryptedHash, err := m.cryptoKeyPub.Encrypt(a.AddrHash())
-			if err != nil {
-				str := fmt.Sprintf("failed to encrypt script hash %x",
-					a.AddrHash())
-				return nil, managerError(ErrCrypto, str, err)
-			}
-
-			err = putScriptAddress(ns, a.AddrHash(), ImportedAddrAccount,
-				ssNone, encryptedHash, a.scriptEncrypted)
-			if err != nil {
-				return nil, maybeConvertDbError(err)
-			}
-		}
-	}
-
-	// Finally update the next address tracking and add the addresses to the
-	// cache after the newly generated addresses have been successfully
-	// added to the db.
-	managedAddresses := make([]ManagedAddress, 0, len(addressInfo))
-	for _, info := range addressInfo {
-		ma := info.managedAddr
-		m.addrs[addrKey(ma.Address().ScriptAddress())] = ma
-
-		// Add the new managed address to the list of addresses that
-		// need their private keys derived when the address manager is
-		// next unlocked.
-		if m.locked && !m.watchingOnly {
-			m.deriveOnUnlock = append(m.deriveOnUnlock, info)
-		}
-
-		managedAddresses = append(managedAddresses, ma)
-	}
-
-	// Set the last address and next address for tracking.
-	ma := addressInfo[len(addressInfo)-1].managedAddr
-	if internal {
-		acctInfo.nextInternalIndex = nextIndex
-		acctInfo.lastInternalAddr = ma
-	} else {
-		acctInfo.nextExternalIndex = nextIndex
-		acctInfo.lastExternalAddr = ma
-	}
-
-	return managedAddresses, nil
-}
-
-// NextExternalAddresses returns the specified number of next chained addresses
-// that are intended for external use from the address manager.
-func (m *Manager) NextExternalAddresses(ns walletdb.ReadWriteBucket, account uint32, numAddresses uint32,
-	addrType AddressType) ([]ManagedAddress, error) {
-
-	// Enforce maximum account number.
-	if account > MaxAccountNum {
-		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
-		return nil, err
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	t := addressTypeToInternal(addrType)
-	return m.nextAddresses(ns, account, numAddresses, false, t)
-}
-
-// NextInternalAddresses returns the specified number of next chained addresses
-// that are intended for internal use such as change from the address manager.
-func (m *Manager) NextInternalAddresses(ns walletdb.ReadWriteBucket, account uint32, numAddresses uint32,
-	addrType AddressType) ([]ManagedAddress, error) {
-
-	// Enforce maximum account number.
-	if account > MaxAccountNum {
-		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
-		return nil, err
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	t := addressTypeToInternal(addrType)
-	return m.nextAddresses(ns, account, numAddresses, true, t)
-}
-
-// LastExternalAddress returns the most recently requested chained external
-// address from calling NextExternalAddress for the given account.  The first
-// external address for the account will be returned if none have been
-// previously requested.
-//
-// This function will return an error if the provided account number is greater
-// than the MaxAccountNum constant or there is no account information for the
-// passed account.  Any other errors returned are generally unexpected.
-func (m *Manager) LastExternalAddress(ns walletdb.ReadBucket, account uint32) (ManagedAddress, error) {
-	// Enforce maximum account number.
-	if account > MaxAccountNum {
-		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
-		return nil, err
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	// Load account information for the passed account.  It is typically
-	// cached, but if not it will be loaded from the database.
-	acctInfo, err := m.loadAccountInfo(ns, account)
-	if err != nil {
-		return nil, err
-	}
-
-	if acctInfo.nextExternalIndex > 0 {
-		return acctInfo.lastExternalAddr, nil
-	}
-
-	return nil, managerError(ErrAddressNotFound, "no previous external address", nil)
-}
-
-// LastInternalAddress returns the most recently requested chained internal
-// address from calling NextInternalAddress for the given account.  The first
-// internal address for the account will be returned if none have been
-// previously requested.
-//
-// This function will return an error if the provided account number is greater
-// than the MaxAccountNum constant or there is no account information for the
-// passed account.  Any other errors returned are generally unexpected.
-func (m *Manager) LastInternalAddress(ns walletdb.ReadBucket, account uint32) (ManagedAddress, error) {
-	// Enforce maximum account number.
-	if account > MaxAccountNum {
-		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
-		return nil, err
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	// Load account information for the passed account.  It is typically
-	// cached, but if not it will be loaded from the database.
-	acctInfo, err := m.loadAccountInfo(ns, account)
-	if err != nil {
-		return nil, err
-	}
-
-	if acctInfo.nextInternalIndex > 0 {
-		return acctInfo.lastInternalAddr, nil
-	}
-
-	return nil, managerError(ErrAddressNotFound, "no previous internal address", nil)
 }
 
 // ValidateAccountName validates the given account name and returns an error, if any.
@@ -1696,226 +1137,6 @@ func ValidateAccountName(name string) error {
 	if isReservedAccountName(name) {
 		str := "reserved account name"
 		return managerError(ErrInvalidAccount, str, nil)
-	}
-	return nil
-}
-
-// NewAccount creates and returns a new account stored in the manager based
-// on the given account name.  If an account with the same name already exists,
-// ErrDuplicateAccount will be returned.  Since creating a new account requires
-// access to the cointype keys (from which extended account keys are derived),
-// it requires the manager to be unlocked.
-func (m *Manager) NewAccount(ns walletdb.ReadWriteBucket, name string) (uint32, error) {
-	if m.watchingOnly {
-		return 0, managerError(ErrWatchingOnly, errWatchingOnly, nil)
-	}
-
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if m.locked {
-		return 0, managerError(ErrLocked, errLocked, nil)
-	}
-
-	// Validate account name
-	if err := ValidateAccountName(name); err != nil {
-		return 0, err
-	}
-
-	// Check that account with the same name does not exist
-	_, err := m.lookupAccount(ns, name)
-	if err == nil {
-		str := fmt.Sprintf("account with the same name already exists")
-		return 0, managerError(ErrDuplicateAccount, str, err)
-	}
-
-	// Fetch latest account, and create a new account in the same transaction
-	// Fetch the latest account number to generate the next account number
-	account, err := fetchLastAccount(ns)
-	if err != nil {
-		return 0, err
-	}
-	account++
-	// Fetch the cointype key which will be used to derive the next account
-	// extended keys
-	_, coinTypePrivEnc, err := fetchCoinTypeKeys(ns)
-	if err != nil {
-		return 0, err
-	}
-
-	// Decrypt the cointype key
-	serializedKeyPriv, err := m.cryptoKeyPriv.Decrypt(coinTypePrivEnc)
-	if err != nil {
-		str := fmt.Sprintf("failed to decrypt cointype serialized private key")
-		return 0, managerError(ErrLocked, str, err)
-	}
-	coinTypeKeyPriv, err := hdkeychain.NewKeyFromString(string(serializedKeyPriv))
-	zero.Bytes(serializedKeyPriv)
-	if err != nil {
-		str := fmt.Sprintf("failed to create cointype extended private key")
-		return 0, managerError(ErrKeyChain, str, err)
-	}
-
-	// Derive the account key using the cointype key
-	acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, account)
-	coinTypeKeyPriv.Zero()
-	if err != nil {
-		str := "failed to convert private key for account"
-		return 0, managerError(ErrKeyChain, str, err)
-	}
-	acctKeyPub, err := acctKeyPriv.Neuter()
-	if err != nil {
-		str := "failed to convert public key for account"
-		return 0, managerError(ErrKeyChain, str, err)
-	}
-	// Encrypt the default account keys with the associated crypto keys.
-	acctPubEnc, err := m.cryptoKeyPub.Encrypt([]byte(acctKeyPub.String()))
-	if err != nil {
-		str := "failed to  encrypt public key for account"
-		return 0, managerError(ErrCrypto, str, err)
-	}
-	acctPrivEnc, err := m.cryptoKeyPriv.Encrypt([]byte(acctKeyPriv.String()))
-	if err != nil {
-		str := "failed to encrypt private key for account"
-		return 0, managerError(ErrCrypto, str, err)
-	}
-	// We have the encrypted account extended keys, so save them to the
-	// database
-	err = putAccountInfo(ns, account, acctPubEnc, acctPrivEnc, 0, 0, name)
-	if err != nil {
-		return 0, err
-	}
-
-	// Save last account metadata
-	if err := putLastAccount(ns, account); err != nil {
-		return 0, err
-	}
-
-	return account, nil
-}
-
-// RenameAccount renames an account stored in the manager based on the
-// given account number with the given name.  If an account with the same name
-// already exists, ErrDuplicateAccount will be returned.
-func (m *Manager) RenameAccount(ns walletdb.ReadWriteBucket, account uint32, name string) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	// Ensure that a reserved account is not being renamed.
-	if isReservedAccountNum(account) {
-		str := "reserved account cannot be renamed"
-		return managerError(ErrInvalidAccount, str, nil)
-	}
-
-	// Check that account with the new name does not exist
-	_, err := m.lookupAccount(ns, name)
-	if err == nil {
-		str := fmt.Sprintf("account with the same name already exists")
-		return managerError(ErrDuplicateAccount, str, err)
-	}
-	// Validate account name
-	if err := ValidateAccountName(name); err != nil {
-		return err
-	}
-
-	rowInterface, err := fetchAccountInfo(ns, account)
-	if err != nil {
-		return err
-	}
-
-	// Ensure the account type is a BIP0044 account.
-	row, ok := rowInterface.(*dbBIP0044AccountRow)
-	if !ok {
-		str := fmt.Sprintf("unsupported account type %T", row)
-		err = managerError(ErrDatabase, str, nil)
-	}
-	// Remove the old name key from the accout id index
-	if err = deleteAccountIDIndex(ns, account); err != nil {
-		return err
-	}
-	// Remove the old name key from the account name index
-	if err = deleteAccountNameIndex(ns, row.name); err != nil {
-		return err
-	}
-	err = putAccountInfo(ns, account, row.pubKeyEncrypted,
-		row.privKeyEncrypted, row.nextExternalIndex, row.nextInternalIndex, name)
-	if err != nil {
-		return err
-	}
-
-	// Update in-memory account info with new name if cached and the db
-	// write was successful.
-	if err == nil {
-		if acctInfo, ok := m.acctInfo[account]; ok {
-			acctInfo.acctName = name
-		}
-	}
-
-	return err
-}
-
-// AccountName returns the account name for the given account number
-// stored in the manager.
-func (m *Manager) AccountName(ns walletdb.ReadBucket, account uint32) (string, error) {
-	return fetchAccountName(ns, account)
-}
-
-// ForEachAccount calls the given function with each account stored in the
-// manager, breaking early on error.
-func (m *Manager) ForEachAccount(ns walletdb.ReadBucket, fn func(account uint32) error) error {
-	return forEachAccount(ns, fn)
-}
-
-// LastAccount returns the last account stored in the manager.
-func (m *Manager) LastAccount(ns walletdb.ReadBucket) (uint32, error) {
-	return fetchLastAccount(ns)
-}
-
-// ForEachAccountAddress calls the given function with each address of
-// the given account stored in the manager, breaking early on error.
-func (m *Manager) ForEachAccountAddress(ns walletdb.ReadBucket, account uint32, fn func(maddr ManagedAddress) error) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	addrFn := func(rowInterface interface{}) error {
-		managedAddr, err := m.rowInterfaceToManaged(ns, rowInterface)
-		if err != nil {
-			return err
-		}
-		return fn(managedAddr)
-	}
-	err := forEachAccountAddress(ns, account, addrFn)
-	if err != nil {
-		return maybeConvertDbError(err)
-	}
-	return nil
-}
-
-// ForEachActiveAccountAddress calls the given function with each active
-// address of the given account stored in the manager, breaking early on
-// error.
-// TODO(tuxcanfly): actually return only active addresses
-func (m *Manager) ForEachActiveAccountAddress(ns walletdb.ReadBucket, account uint32, fn func(maddr ManagedAddress) error) error {
-	return m.ForEachAccountAddress(ns, account, fn)
-}
-
-// ForEachActiveAddress calls the given function with each active address
-// stored in the manager, breaking early on error.
-func (m *Manager) ForEachActiveAddress(ns walletdb.ReadBucket, fn func(addr btcutil.Address) error) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	addrFn := func(rowInterface interface{}) error {
-		managedAddr, err := m.rowInterfaceToManaged(ns, rowInterface)
-		if err != nil {
-			return err
-		}
-		return fn(managedAddr.Address())
-	}
-
-	err := forEachActiveAddress(ns, addrFn)
-	if err != nil {
-		return maybeConvertDbError(err)
 	}
 	return nil
 }
@@ -1970,8 +1191,8 @@ func (m *Manager) Encrypt(keyType CryptoKeyType, in []byte) ([]byte, error) {
 
 // Decrypt in using the crypto key type specified by keyType.
 func (m *Manager) Decrypt(keyType CryptoKeyType, in []byte) ([]byte, error) {
-	// Decryption must be performed under the manager mutex since the
-	// keys are cleared when the manager is locked.
+	// Decryption must be performed under the manager mutex since the keys
+	// are cleared when the manager is locked.
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
@@ -1991,15 +1212,14 @@ func (m *Manager) Decrypt(keyType CryptoKeyType, in []byte) ([]byte, error) {
 func newManager(chainParams *chaincfg.Params, masterKeyPub *snacl.SecretKey,
 	masterKeyPriv *snacl.SecretKey, cryptoKeyPub EncryptorDecryptor,
 	cryptoKeyPrivEncrypted, cryptoKeyScriptEncrypted []byte, syncInfo *syncState,
-	birthday time.Time, privPassphraseSalt [saltSize]byte) *Manager {
+	birthday time.Time, privPassphraseSalt [saltSize]byte,
+	scopedManagers map[KeyScope]*ScopedKeyManager) *Manager {
 
-	return &Manager{
+	m := &Manager{
 		chainParams:              chainParams,
-		addrs:                    make(map[addrKey]ManagedAddress),
 		syncState:                *syncInfo,
-		birthday:                 birthday,
 		locked:                   true,
-		acctInfo:                 make(map[uint32]*accountInfo),
+		birthday:                 birthday,
 		masterKeyPub:             masterKeyPub,
 		masterKeyPriv:            masterKeyPriv,
 		cryptoKeyPub:             cryptoKeyPub,
@@ -2008,7 +1228,25 @@ func newManager(chainParams *chaincfg.Params, masterKeyPub *snacl.SecretKey,
 		cryptoKeyScriptEncrypted: cryptoKeyScriptEncrypted,
 		cryptoKeyScript:          &cryptoKey{},
 		privPassphraseSalt:       privPassphraseSalt,
+		scopedManagers:           scopedManagers,
+		externalAddrSchemas:      make(map[AddressType][]KeyScope),
+		internalAddrSchemas:      make(map[AddressType][]KeyScope),
 	}
+
+	for _, sMgr := range m.scopedManagers {
+		externalType := sMgr.AddrSchema().ExternalAddrType
+		internalType := sMgr.AddrSchema().InternalAddrType
+		scope := sMgr.Scope()
+
+		m.externalAddrSchemas[externalType] = append(
+			m.externalAddrSchemas[externalType], scope,
+		)
+		m.internalAddrSchemas[internalType] = append(
+			m.internalAddrSchemas[internalType], scope,
+		)
+	}
+
+	return m
 }
 
 // deriveCoinTypeKey derives the cointype key which can be used to derive the
@@ -2016,30 +1254,35 @@ func newManager(chainParams *chaincfg.Params, masterKeyPub *snacl.SecretKey,
 // given the coin type key.
 //
 // In particular this is the hierarchical deterministic extended key path:
-// m/44'/<coin type>'
+// m/purpose'/<coin type>'
 func deriveCoinTypeKey(masterNode *hdkeychain.ExtendedKey,
-	coinType uint32) (*hdkeychain.ExtendedKey, error) {
+	scope KeyScope) (*hdkeychain.ExtendedKey, error) {
+
 	// Enforce maximum coin type.
-	if coinType > maxCoinType {
+	if scope.Coin > maxCoinType {
 		err := managerError(ErrCoinTypeTooHigh, errCoinTypeTooHigh, nil)
 		return nil, err
 	}
 
 	// The hierarchy described by BIP0043 is:
 	//  m/<purpose>'/*
+	//
 	// This is further extended by BIP0044 to:
 	//  m/44'/<coin type>'/<account>'/<branch>/<address index>
+	//
+	// However, as this is a generic key store for any family for BIP0044
+	// standards, we'll use the custom scope to govern our key derivation.
 	//
 	// The branch is 0 for external addresses and 1 for internal addresses.
 
 	// Derive the purpose key as a child of the master node.
-	purpose, err := masterNode.Child(44 + hdkeychain.HardenedKeyStart)
+	purpose, err := masterNode.Child(scope.Purpose + hdkeychain.HardenedKeyStart)
 	if err != nil {
 		return nil, err
 	}
 
 	// Derive the coin type key as a child of the purpose key.
-	coinTypeKey, err := purpose.Child(coinType + hdkeychain.HardenedKeyStart)
+	coinTypeKey, err := purpose.Child(scope.Coin + hdkeychain.HardenedKeyStart)
 	if err != nil {
 		return nil, err
 	}
@@ -2051,9 +1294,10 @@ func deriveCoinTypeKey(masterNode *hdkeychain.ExtendedKey,
 // hierarchy described by BIP0044 given the master node.
 //
 // In particular this is the hierarchical deterministic extended key path:
-//   m/44'/<coin type>'/<account>'
+//   m/purpose'/<coin type>'/<account>'
 func deriveAccountKey(coinTypeKey *hdkeychain.ExtendedKey,
 	account uint32) (*hdkeychain.ExtendedKey, error) {
+
 	// Enforce maximum account number.
 	if account > MaxAccountNum {
 		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
@@ -2067,11 +1311,11 @@ func deriveAccountKey(coinTypeKey *hdkeychain.ExtendedKey,
 // checkBranchKeys ensures deriving the extended keys for the internal and
 // external branches given an account key does not result in an invalid child
 // error which means the chosen seed is not usable.  This conforms to the
-// hierarchy described by BIP0044 so long as the account key is already derived
-// accordingly.
+// hierarchy described by the BIP0044 family so long as the account key is
+// already derived accordingly.
 //
 // In particular this is the hierarchical deterministic extended key path:
-//   m/44'/<coin type>'/<account>'/<branch>
+//   m/purpose'/<coin type>'/<account>'/<branch>
 //
 // The branch is 0 for external addresses and 1 for internal addresses.
 func checkBranchKeys(acctKey *hdkeychain.ExtendedKey) error {
@@ -2086,9 +1330,11 @@ func checkBranchKeys(acctKey *hdkeychain.ExtendedKey) error {
 }
 
 // loadManager returns a new address manager that results from loading it from
-// the passed opened database.  The public passphrase is required to decrypt the
-// public keys.
-func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chaincfg.Params) (*Manager, error) {
+// the passed opened database.  The public passphrase is required to decrypt
+// the public keys.
+func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
+	chainParams *chaincfg.Params) (*Manager, error) {
+
 	// Verify the version is neither too old or too new.
 	version, err := fetchManagerVersion(ns)
 	if err != nil {
@@ -2180,13 +1426,43 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chai
 		return nil, managerError(ErrCrypto, str, err)
 	}
 
-	// Create new address manager with the given parameters.  Also, override
-	// the defaults for the additional fields which are not specified in the
-	// call to new with the values loaded from the database.
-	mgr := newManager(chainParams, &masterKeyPub, &masterKeyPriv,
+	// Next, we'll need to load all known manager scopes from disk. Each
+	// scope is on a distinct top-level path within our HD key chain.
+	scopedManagers := make(map[KeyScope]*ScopedKeyManager)
+	err = forEachKeyScope(ns, func(scope KeyScope) error {
+		scopeSchema, err := fetchScopeAddrSchema(ns, &scope)
+		if err != nil {
+			return err
+		}
+
+		scopedManagers[scope] = &ScopedKeyManager{
+			scope:      scope,
+			addrSchema: *scopeSchema,
+			addrs:      make(map[addrKey]ManagedAddress),
+			acctInfo:   make(map[uint32]*accountInfo),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new address manager with the given parameters.  Also,
+	// override the defaults for the additional fields which are not
+	// specified in the call to new with the values loaded from the
+	// database.
+	mgr := newManager(
+		chainParams, &masterKeyPub, &masterKeyPriv,
 		cryptoKeyPub, cryptoKeyPrivEnc, cryptoKeyScriptEnc, syncInfo,
-		birthday, privPassphraseSalt)
+		birthday, privPassphraseSalt, scopedManagers,
+	)
 	mgr.watchingOnly = watchingOnly
+
+	for _, scopedManager := range scopedManagers {
+		scopedManager.rootManager = mgr
+	}
+
 	return mgr, nil
 }
 
@@ -2195,12 +1471,14 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chai
 // information such as addresses.  This is important since access to BIP0032
 // extended keys means it is possible to generate all future addresses.
 //
-// If a config structure is passed to the function, that configuration
-// will override the defaults.
+// If a config structure is passed to the function, that configuration will
+// override the defaults.
 //
 // A ManagerError with an error code of ErrNoExist will be returned if the
 // passed manager does not exist in the specified namespace.
-func Open(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chaincfg.Params) (*Manager, error) {
+func Open(ns walletdb.ReadBucket, pubPassphrase []byte,
+	chainParams *chaincfg.Params) (*Manager, error) {
+
 	// Return an error if the manager has NOT already been created in the
 	// given database namespace.
 	exists := managerExists(ns)
@@ -2220,6 +1498,107 @@ func DoUpgrades(db walletdb.DB, namespaceKey []byte, pubPassphrase []byte,
 	return upgradeManager(db, namespaceKey, pubPassphrase, chainParams, cbs)
 }
 
+// createManagerKeyScope creates a new key scoped for a target manager's scope.
+// This partitions key derivation for a particular purpose+coin tuple, allowing
+// multiple address derivation schems to be maintained concurrently.
+func createManagerKeyScope(ns walletdb.ReadWriteBucket,
+	scope KeyScope, root *hdkeychain.ExtendedKey,
+	cryptoKeyPub, cryptoKeyPriv EncryptorDecryptor) error {
+
+	// Derive the cointype key according to the passed scope.
+	coinTypeKeyPriv, err := deriveCoinTypeKey(root, scope)
+	if err != nil {
+		str := "failed to derive cointype extended key"
+		return managerError(ErrKeyChain, str, err)
+	}
+	defer coinTypeKeyPriv.Zero()
+
+	// Derive the account key for the first account according our
+	// BIP0044-like derivation.
+	acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, 0)
+	if err != nil {
+		// The seed is unusable if the any of the children in the
+		// required hierarchy can't be derived due to invalid child.
+		if err == hdkeychain.ErrInvalidChild {
+			str := "the provided seed is unusable"
+			return managerError(ErrKeyChain, str,
+				hdkeychain.ErrUnusableSeed)
+		}
+
+		return err
+	}
+
+	// Ensure the branch keys can be derived for the provided seed according
+	// to our BIP0044-like derivation.
+	if err := checkBranchKeys(acctKeyPriv); err != nil {
+		// The seed is unusable if the any of the children in the
+		// required hierarchy can't be derived due to invalid child.
+		if err == hdkeychain.ErrInvalidChild {
+			str := "the provided seed is unusable"
+			return managerError(ErrKeyChain, str,
+				hdkeychain.ErrUnusableSeed)
+		}
+
+		return err
+	}
+
+	// The address manager needs the public extended key for the account.
+	acctKeyPub, err := acctKeyPriv.Neuter()
+	if err != nil {
+		str := "failed to convert private key for account 0"
+		return managerError(ErrKeyChain, str, err)
+	}
+
+	// Encrypt the cointype keys with the associated crypto keys.
+	coinTypeKeyPub, err := coinTypeKeyPriv.Neuter()
+	if err != nil {
+		str := "failed to convert cointype private key"
+		return managerError(ErrKeyChain, str, err)
+	}
+	coinTypePubEnc, err := cryptoKeyPub.Encrypt([]byte(coinTypeKeyPub.String()))
+	if err != nil {
+		str := "failed to encrypt cointype public key"
+		return managerError(ErrCrypto, str, err)
+	}
+	coinTypePrivEnc, err := cryptoKeyPriv.Encrypt([]byte(coinTypeKeyPriv.String()))
+	if err != nil {
+		str := "failed to encrypt cointype private key"
+		return managerError(ErrCrypto, str, err)
+	}
+
+	// Encrypt the default account keys with the associated crypto keys.
+	acctPubEnc, err := cryptoKeyPub.Encrypt([]byte(acctKeyPub.String()))
+	if err != nil {
+		str := "failed to  encrypt public key for account 0"
+		return managerError(ErrCrypto, str, err)
+	}
+	acctPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(acctKeyPriv.String()))
+	if err != nil {
+		str := "failed to encrypt private key for account 0"
+		return managerError(ErrCrypto, str, err)
+	}
+
+	// Save the encrypted cointype keys to the database.
+	err = putCoinTypeKeys(ns, &scope, coinTypePubEnc, coinTypePrivEnc)
+	if err != nil {
+		return err
+	}
+
+	// Save the information for the default account to the database.
+	err = putAccountInfo(
+		ns, &scope, DefaultAccountNum, acctPubEnc, acctPrivEnc, 0, 0,
+		defaultAccountName,
+	)
+	if err != nil {
+		return err
+	}
+
+	return putAccountInfo(
+		ns, &scope, ImportedAddrAccount, nil, nil, 0, 0,
+		ImportedAddrAccountName,
+	)
+}
+
 // Create creates a new address manager in the given namespace.  The seed must
 // conform to the standards described in hdkeychain.NewMaster and will be used
 // to create the master root node from which all hierarchical deterministic
@@ -2229,247 +1608,182 @@ func DoUpgrades(db walletdb.DB, namespaceKey []byte, pubPassphrase []byte,
 // All private and public keys and information are protected by secret keys
 // derived from the provided private and public passphrases.  The public
 // passphrase is required on subsequent opens of the address manager, and the
-// private passphrase is required to unlock the address manager in order to gain
-// access to any private keys and information.
+// private passphrase is required to unlock the address manager in order to
+// gain access to any private keys and information.
 //
-// If a config structure is passed to the function, that configuration
-// will override the defaults.
+// If a config structure is passed to the function, that configuration will
+// override the defaults.
 //
 // A ManagerError with an error code of ErrAlreadyExists will be returned the
 // address manager already exists in the specified namespace.
-func Create(ns walletdb.ReadWriteBucket, seed, pubPassphrase, privPassphrase []byte, chainParams *chaincfg.Params, config *ScryptOptions) error {
-	err := func() error {
-		// Return an error if the manager has already been created in the given
-		// database namespace.
-		exists := managerExists(ns)
-		if exists {
-			return managerError(ErrAlreadyExists, errAlreadyExists, nil)
-		}
+func Create(ns walletdb.ReadWriteBucket, seed, pubPassphrase, privPassphrase []byte,
+	chainParams *chaincfg.Params, config *ScryptOptions) error {
 
-		// Ensure the private passphrase is not empty.
-		if len(privPassphrase) == 0 {
-			str := "private passphrase may not be empty"
-			return managerError(ErrEmptyPassphrase, str, nil)
-		}
+	// Return an error if the manager has already been created in
+	// the given database namespace.
+	exists := managerExists(ns)
+	if exists {
+		return managerError(ErrAlreadyExists, errAlreadyExists, nil)
+	}
 
-		// Perform the initial bucket creation and database namespace setup.
-		if err := createManagerNS(ns); err != nil {
-			return err
-		}
+	// Ensure the private passphrase is not empty.
+	if len(privPassphrase) == 0 {
+		str := "private passphrase may not be empty"
+		return managerError(ErrEmptyPassphrase, str, nil)
+	}
 
-		if config == nil {
-			config = &DefaultScryptOptions
-		}
+	// Perform the initial bucket creation and database namespace setup.
+	if err := createManagerNS(ns, ScopeAddrMap); err != nil {
+		return maybeConvertDbError(err)
+	}
 
-		// Generate the BIP0044 HD key structure to ensure the provided seed
-		// can generate the required structure with no issues.
+	if config == nil {
+		config = &DefaultScryptOptions
+	}
 
-		// Derive the master extended key from the seed.
-		root, err := hdkeychain.NewMaster(seed, chainParams)
-		if err != nil {
-			str := "failed to derive master extended key"
-			return managerError(ErrKeyChain, str, err)
-		}
+	// Generate new master keys.  These master keys are used to protect the
+	// crypto keys that will be generated next.
+	masterKeyPub, err := newSecretKey(&pubPassphrase, config)
+	if err != nil {
+		str := "failed to master public key"
+		return managerError(ErrCrypto, str, err)
+	}
+	masterKeyPriv, err := newSecretKey(&privPassphrase, config)
+	if err != nil {
+		str := "failed to master private key"
+		return managerError(ErrCrypto, str, err)
+	}
+	defer masterKeyPriv.Zero()
 
-		// Derive the cointype key according to BIP0044.
-		coinTypeKeyPriv, err := deriveCoinTypeKey(root, chainParams.HDCoinType)
-		if err != nil {
-			str := "failed to derive cointype extended key"
-			return managerError(ErrKeyChain, str, err)
-		}
-		defer coinTypeKeyPriv.Zero()
+	// Generate the private passphrase salt.  This is used when hashing
+	// passwords to detect whether an unlock can be avoided when the manager
+	// is already unlocked.
+	var privPassphraseSalt [saltSize]byte
+	_, err = rand.Read(privPassphraseSalt[:])
+	if err != nil {
+		str := "failed to read random source for passphrase salt"
+		return managerError(ErrCrypto, str, err)
+	}
 
-		// Derive the account key for the first account according to BIP0044.
-		acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, 0)
-		if err != nil {
-			// The seed is unusable if the any of the children in the
-			// required hierarchy can't be derived due to invalid child.
-			if err == hdkeychain.ErrInvalidChild {
-				str := "the provided seed is unusable"
-				return managerError(ErrKeyChain, str,
-					hdkeychain.ErrUnusableSeed)
-			}
+	// Generate new crypto public, private, and script keys.  These keys are
+	// used to protect the actual public and private data such as addresses,
+	// extended keys, and scripts.
+	cryptoKeyPub, err := newCryptoKey()
+	if err != nil {
+		str := "failed to generate crypto public key"
+		return managerError(ErrCrypto, str, err)
+	}
+	cryptoKeyPriv, err := newCryptoKey()
+	if err != nil {
+		str := "failed to generate crypto private key"
+		return managerError(ErrCrypto, str, err)
+	}
+	defer cryptoKeyPriv.Zero()
+	cryptoKeyScript, err := newCryptoKey()
+	if err != nil {
+		str := "failed to generate crypto script key"
+		return managerError(ErrCrypto, str, err)
+	}
+	defer cryptoKeyScript.Zero()
 
-			return err
-		}
+	// Encrypt the crypto keys with the associated master keys.
+	cryptoKeyPubEnc, err := masterKeyPub.Encrypt(cryptoKeyPub.Bytes())
+	if err != nil {
+		str := "failed to encrypt crypto public key"
+		return managerError(ErrCrypto, str, err)
+	}
+	cryptoKeyPrivEnc, err := masterKeyPriv.Encrypt(cryptoKeyPriv.Bytes())
+	if err != nil {
+		str := "failed to encrypt crypto private key"
+		return managerError(ErrCrypto, str, err)
+	}
+	cryptoKeyScriptEnc, err := masterKeyPriv.Encrypt(cryptoKeyScript.Bytes())
+	if err != nil {
+		str := "failed to encrypt crypto script key"
+		return managerError(ErrCrypto, str, err)
+	}
 
-		// Ensure the branch keys can be derived for the provided seed according
-		// to BIP0044.
-		if err := checkBranchKeys(acctKeyPriv); err != nil {
-			// The seed is unusable if the any of the children in the
-			// required hierarchy can't be derived due to invalid child.
-			if err == hdkeychain.ErrInvalidChild {
-				str := "the provided seed is unusable"
-				return managerError(ErrKeyChain, str,
-					hdkeychain.ErrUnusableSeed)
-			}
+	// Use the genesis block for the passed chain as the created at block
+	// for the default.
+	createdAt := &BlockStamp{Hash: *chainParams.GenesisHash, Height: 0}
 
-			return err
-		}
+	// Create the initial sync state.
+	syncInfo := newSyncState(createdAt, createdAt)
 
-		// The address manager needs the public extended key for the account.
-		acctKeyPub, err := acctKeyPriv.Neuter()
-		if err != nil {
-			str := "failed to convert private key for account 0"
-			return managerError(ErrKeyChain, str, err)
-		}
-
-		// Generate new master keys.  These master keys are used to protect the
-		// crypto keys that will be generated next.
-		masterKeyPub, err := newSecretKey(&pubPassphrase, config)
-		if err != nil {
-			str := "failed to master public key"
-			return managerError(ErrCrypto, str, err)
-		}
-		masterKeyPriv, err := newSecretKey(&privPassphrase, config)
-		if err != nil {
-			str := "failed to master private key"
-			return managerError(ErrCrypto, str, err)
-		}
-		defer masterKeyPriv.Zero()
-
-		// Generate the private passphrase salt.  This is used when hashing
-		// passwords to detect whether an unlock can be avoided when the manager
-		// is already unlocked.
-		var privPassphraseSalt [saltSize]byte
-		_, err = rand.Read(privPassphraseSalt[:])
-		if err != nil {
-			str := "failed to read random source for passphrase salt"
-			return managerError(ErrCrypto, str, err)
-		}
-
-		// Generate new crypto public, private, and script keys.  These keys are
-		// used to protect the actual public and private data such as addresses,
-		// extended keys, and scripts.
-		cryptoKeyPub, err := newCryptoKey()
-		if err != nil {
-			str := "failed to generate crypto public key"
-			return managerError(ErrCrypto, str, err)
-		}
-		cryptoKeyPriv, err := newCryptoKey()
-		if err != nil {
-			str := "failed to generate crypto private key"
-			return managerError(ErrCrypto, str, err)
-		}
-		defer cryptoKeyPriv.Zero()
-		cryptoKeyScript, err := newCryptoKey()
-		if err != nil {
-			str := "failed to generate crypto script key"
-			return managerError(ErrCrypto, str, err)
-		}
-		defer cryptoKeyScript.Zero()
-
-		// Encrypt the crypto keys with the associated master keys.
-		cryptoKeyPubEnc, err := masterKeyPub.Encrypt(cryptoKeyPub.Bytes())
-		if err != nil {
-			str := "failed to encrypt crypto public key"
-			return managerError(ErrCrypto, str, err)
-		}
-		cryptoKeyPrivEnc, err := masterKeyPriv.Encrypt(cryptoKeyPriv.Bytes())
-		if err != nil {
-			str := "failed to encrypt crypto private key"
-			return managerError(ErrCrypto, str, err)
-		}
-		cryptoKeyScriptEnc, err := masterKeyPriv.Encrypt(cryptoKeyScript.Bytes())
-		if err != nil {
-			str := "failed to encrypt crypto script key"
-			return managerError(ErrCrypto, str, err)
-		}
-
-		// Encrypt the cointype keys with the associated crypto keys.
-		coinTypeKeyPub, err := coinTypeKeyPriv.Neuter()
-		if err != nil {
-			str := "failed to convert cointype private key"
-			return managerError(ErrKeyChain, str, err)
-		}
-		coinTypePubEnc, err := cryptoKeyPub.Encrypt([]byte(coinTypeKeyPub.String()))
-		if err != nil {
-			str := "failed to encrypt cointype public key"
-			return managerError(ErrCrypto, str, err)
-		}
-		coinTypePrivEnc, err := cryptoKeyPriv.Encrypt([]byte(coinTypeKeyPriv.String()))
-		if err != nil {
-			str := "failed to encrypt cointype private key"
-			return managerError(ErrCrypto, str, err)
-		}
-
-		// Encrypt the default account keys with the associated crypto keys.
-		acctPubEnc, err := cryptoKeyPub.Encrypt([]byte(acctKeyPub.String()))
-		if err != nil {
-			str := "failed to  encrypt public key for account 0"
-			return managerError(ErrCrypto, str, err)
-		}
-		acctPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(acctKeyPriv.String()))
-		if err != nil {
-			str := "failed to encrypt private key for account 0"
-			return managerError(ErrCrypto, str, err)
-		}
-
-		// Use the genesis block for the passed chain as the created at block
-		// for the default.
-		createdAt := &BlockStamp{Hash: *chainParams.GenesisHash, Height: 0}
-
-		// Create the initial sync state.
-		syncInfo := newSyncState(createdAt, createdAt)
-
-		// Save the master key params to the database.
-		pubParams := masterKeyPub.Marshal()
-		privParams := masterKeyPriv.Marshal()
-		err = putMasterKeyParams(ns, pubParams, privParams)
-		if err != nil {
-			return err
-		}
-
-		// Save the encrypted crypto keys to the database.
-		err = putCryptoKeys(ns, cryptoKeyPubEnc, cryptoKeyPrivEnc,
-			cryptoKeyScriptEnc)
-		if err != nil {
-			return err
-		}
-
-		// Save the encrypted cointype keys to the database.
-		err = putCoinTypeKeys(ns, coinTypePubEnc, coinTypePrivEnc)
-		if err != nil {
-			return err
-		}
-
-		// Save the fact this is not a watching-only address manager to
-		// the database.
-		err = putWatchingOnly(ns, false)
-		if err != nil {
-			return err
-		}
-
-		// Save the initial synced to state.
-		err = putSyncedTo(ns, &syncInfo.syncedTo)
-		if err != nil {
-			return err
-		}
-		err = putStartBlock(ns, &syncInfo.startBlock)
-		if err != nil {
-			return err
-		}
-		// Use 48 hours as margin of safety for wallet birthday.
-		err = putBirthday(ns, time.Now().Add(-48*time.Hour))
-		if err != nil {
-			return err
-		}
-
-		// Save the information for the imported account to the database.
-		err = putAccountInfo(ns, ImportedAddrAccount, nil,
-			nil, 0, 0, ImportedAddrAccountName)
-		if err != nil {
-			return err
-		}
-
-		// Save the information for the default account to the database.
-		err = putAccountInfo(ns, DefaultAccountNum, acctPubEnc,
-			acctPrivEnc, 0, 0, defaultAccountName)
-		return err
-	}()
+	// Save the master key params to the database.
+	pubParams := masterKeyPub.Marshal()
+	privParams := masterKeyPriv.Marshal()
+	err = putMasterKeyParams(ns, pubParams, privParams)
 	if err != nil {
 		return maybeConvertDbError(err)
 	}
 
-	return nil
+	// Generate the BIP0044 HD key structure to ensure the provided seed
+	// can generate the required structure with no issues.
+
+	// Derive the master extended key from the seed.
+	rootKey, err := hdkeychain.NewMaster(seed, chainParams)
+	if err != nil {
+		str := "failed to derive master extended key"
+		return managerError(ErrKeyChain, str, err)
+	}
+	rootPubKey, err := rootKey.Neuter()
+	if err != nil {
+		str := "failed to neuter master extended key"
+		return managerError(ErrKeyChain, str, err)
+	}
+
+	// Next, for each registers default manager scope, we'll create the
+	// hardened cointype key for it, as well as the first default account.
+	for _, defaultScope := range DefaultKeyScopes {
+		err := createManagerKeyScope(
+			ns, defaultScope, rootKey, cryptoKeyPub, cryptoKeyPriv,
+		)
+		if err != nil {
+			return maybeConvertDbError(err)
+		}
+	}
+
+	// Before we proceed, we'll also store the root master private key
+	// within the database in an encrypted format. This is required as in
+	// the future, we may need to create additional scoped key managers.
+	masterHDPrivKeyEnc, err := cryptoKeyPriv.Encrypt([]byte(rootKey.String()))
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+	masterHDPubKeyEnc, err := cryptoKeyPub.Encrypt([]byte(rootPubKey.String()))
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+	err = putMasterHDKeys(ns, masterHDPrivKeyEnc, masterHDPubKeyEnc)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	// Save the encrypted crypto keys to the database.
+	err = putCryptoKeys(ns, cryptoKeyPubEnc, cryptoKeyPrivEnc,
+		cryptoKeyScriptEnc)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	// Save the fact this is not a watching-only address manager to the
+	// database.
+	err = putWatchingOnly(ns, false)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	// Save the initial synced to state.
+	err = putSyncedTo(ns, &syncInfo.syncedTo)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+	err = putStartBlock(ns, &syncInfo.startBlock)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	// Use 48 hours as margin of safety for wallet birthday.
+	return putBirthday(ns, time.Now().Add(-48*time.Hour))
 }

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/roasbeef/btcd/chaincfg"
 	"github.com/roasbeef/btcd/chaincfg/chainhash"
@@ -1699,8 +1700,9 @@ func testSync(tc *testContext) bool {
 		return false
 	}
 	blockStamp = waddrmgr.BlockStamp{
-		Height: 1,
-		Hash:   *latestHash,
+		Height:    1,
+		Hash:      *latestHash,
+		Timestamp: time.Unix(1234, 0),
 	}
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -5,6 +5,7 @@
 package waddrmgr_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -41,7 +42,8 @@ func newHash(hexStr string) *chainhash.Hash {
 type testContext struct {
 	t            *testing.T
 	db           walletdb.DB
-	manager      *waddrmgr.Manager
+	rootManager  *waddrmgr.Manager
+	manager      *waddrmgr.ScopedKeyManager
 	account      uint32
 	create       bool
 	unlocked     bool
@@ -89,7 +91,9 @@ func testNamePrefix(tc *testContext) string {
 // When the test context indicates the manager is unlocked, the private data
 // will also be tested, otherwise, the functions which deal with private data
 // are checked to ensure they return the correct error.
-func testManagedPubKeyAddress(tc *testContext, prefix string, gotAddr waddrmgr.ManagedPubKeyAddress, wantAddr *expectedAddr) bool {
+func testManagedPubKeyAddress(tc *testContext, prefix string,
+	gotAddr waddrmgr.ManagedPubKeyAddress, wantAddr *expectedAddr) bool {
+
 	// Ensure pubkey is the expected value for the managed address.
 	var gpubBytes []byte
 	if gotAddr.Compressed() {
@@ -297,7 +301,7 @@ func testExternalAddresses(tc *testContext) bool {
 		err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 			var err error
-			addrs, err = tc.manager.NextExternalAddresses(ns, tc.account, 5, waddrmgr.PubKeyHash)
+			addrs, err = tc.manager.NextExternalAddresses(ns, tc.account, 5)
 			return err
 		})
 		if err != nil {
@@ -348,8 +352,9 @@ func testExternalAddresses(tc *testContext) bool {
 		chainParams := tc.manager.ChainParams()
 		for i := 0; i < len(expectedExternalAddrs); i++ {
 			pkHash := expectedExternalAddrs[i].addressHash
-			utilAddr, err := btcutil.NewAddressPubKeyHash(pkHash,
-				chainParams)
+			utilAddr, err := btcutil.NewAddressPubKeyHash(
+				pkHash, chainParams,
+			)
 			if err != nil {
 				tc.t.Errorf("%s NewAddressPubKeyHash #%d: "+
 					"unexpected error: %v", prefix, i, err)
@@ -396,7 +401,7 @@ func testExternalAddresses(tc *testContext) bool {
 	// private information is valid as well.
 	err := walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		return tc.manager.Unlock(ns, privPassphrase)
+		return tc.rootManager.Unlock(ns, privPassphrase)
 	})
 	if err != nil {
 		tc.t.Errorf("Unlock: unexpected error: %v", err)
@@ -408,7 +413,7 @@ func testExternalAddresses(tc *testContext) bool {
 	}
 
 	// Relock the manager for future tests.
-	if err := tc.manager.Lock(); err != nil {
+	if err := tc.rootManager.Lock(); err != nil {
 		tc.t.Errorf("Lock: unexpected error: %v", err)
 		return false
 	}
@@ -432,7 +437,7 @@ func testInternalAddresses(tc *testContext) bool {
 		// private information is valid as well.
 		err := walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 			ns := tx.ReadBucket(waddrmgrNamespaceKey)
-			return tc.manager.Unlock(ns, privPassphrase)
+			return tc.rootManager.Unlock(ns, privPassphrase)
 		})
 		if err != nil {
 			tc.t.Errorf("Unlock: unexpected error: %v", err)
@@ -448,7 +453,7 @@ func testInternalAddresses(tc *testContext) bool {
 		err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 			var err error
-			addrs, err = tc.manager.NextInternalAddresses(ns, tc.account, 5, waddrmgr.PubKeyHash)
+			addrs, err = tc.manager.NextInternalAddresses(ns, tc.account, 5)
 			return err
 		})
 		if err != nil {
@@ -499,8 +504,9 @@ func testInternalAddresses(tc *testContext) bool {
 		chainParams := tc.manager.ChainParams()
 		for i := 0; i < len(expectedInternalAddrs); i++ {
 			pkHash := expectedInternalAddrs[i].addressHash
-			utilAddr, err := btcutil.NewAddressPubKeyHash(pkHash,
-				chainParams)
+			utilAddr, err := btcutil.NewAddressPubKeyHash(
+				pkHash, chainParams,
+			)
 			if err != nil {
 				tc.t.Errorf("%s NewAddressPubKeyHash #%d: "+
 					"unexpected error: %v", prefix, i, err)
@@ -550,7 +556,7 @@ func testInternalAddresses(tc *testContext) bool {
 	// Lock the manager and retest all of the addresses to ensure the
 	// public information remains valid and the private functions return
 	// the expected error.
-	if err := tc.manager.Lock(); err != nil {
+	if err := tc.rootManager.Lock(); err != nil {
 		tc.t.Errorf("Lock: unexpected error: %v", err)
 		return false
 	}
@@ -570,7 +576,7 @@ func testLocking(tc *testContext) bool {
 		tc.t.Error("testLocking called with an unlocked manager")
 		return false
 	}
-	if !tc.manager.IsLocked() {
+	if !tc.rootManager.IsLocked() {
 		tc.t.Error("IsLocked: returned false on locked manager")
 		return false
 	}
@@ -578,7 +584,7 @@ func testLocking(tc *testContext) bool {
 	// Locking an already lock manager should return an error.  The error
 	// should be ErrLocked or ErrWatchingOnly depending on the type of the
 	// address manager.
-	err := tc.manager.Lock()
+	err := tc.rootManager.Lock()
 	wantErrCode := waddrmgr.ErrLocked
 	if tc.watchingOnly {
 		wantErrCode = waddrmgr.ErrWatchingOnly
@@ -593,7 +599,7 @@ func testLocking(tc *testContext) bool {
 	// the correct error for that case.
 	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		return tc.manager.Unlock(ns, privPassphrase)
+		return tc.rootManager.Unlock(ns, privPassphrase)
 	})
 	if tc.watchingOnly {
 		if !checkManagerError(tc.t, "Unlock", err, waddrmgr.ErrWatchingOnly) {
@@ -603,7 +609,7 @@ func testLocking(tc *testContext) bool {
 		tc.t.Errorf("Unlock: unexpected error: %v", err)
 		return false
 	}
-	if !tc.watchingOnly && tc.manager.IsLocked() {
+	if !tc.watchingOnly && tc.rootManager.IsLocked() {
 		tc.t.Error("IsLocked: returned true on unlocked manager")
 		return false
 	}
@@ -613,7 +619,7 @@ func testLocking(tc *testContext) bool {
 	// case.
 	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		return tc.manager.Unlock(ns, privPassphrase)
+		return tc.rootManager.Unlock(ns, privPassphrase)
 	})
 	if tc.watchingOnly {
 		if !checkManagerError(tc.t, "Unlock2", err, waddrmgr.ErrWatchingOnly) {
@@ -623,7 +629,7 @@ func testLocking(tc *testContext) bool {
 		tc.t.Errorf("Unlock: unexpected error: %v", err)
 		return false
 	}
-	if !tc.watchingOnly && tc.manager.IsLocked() {
+	if !tc.watchingOnly && tc.rootManager.IsLocked() {
 		tc.t.Error("IsLocked: returned true on unlocked manager")
 		return false
 	}
@@ -632,7 +638,7 @@ func testLocking(tc *testContext) bool {
 	// error and a locked manager.
 	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		return tc.manager.Unlock(ns, []byte("invalidpassphrase"))
+		return tc.rootManager.Unlock(ns, []byte("invalidpassphrase"))
 	})
 	wantErrCode = waddrmgr.ErrWrongPassphrase
 	if tc.watchingOnly {
@@ -641,7 +647,7 @@ func testLocking(tc *testContext) bool {
 	if !checkManagerError(tc.t, "Unlock", err, wantErrCode) {
 		return false
 	}
-	if !tc.manager.IsLocked() {
+	if !tc.rootManager.IsLocked() {
 		tc.t.Error("IsLocked: manager is unlocked after failed unlock " +
 			"attempt")
 		return false
@@ -701,7 +707,7 @@ func testImportPrivateKey(tc *testContext) bool {
 	if !tc.watchingOnly {
 		err := walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 			ns := tx.ReadBucket(waddrmgrNamespaceKey)
-			return tc.manager.Unlock(ns, privPassphrase)
+			return tc.rootManager.Unlock(ns, privPassphrase)
 		})
 		if err != nil {
 			tc.t.Errorf("Unlock: unexpected error: %v", err)
@@ -805,7 +811,7 @@ func testImportPrivateKey(tc *testContext) bool {
 
 	// Lock the manager and retest all of the addresses to ensure the
 	// private information returns the expected error.
-	if err := tc.manager.Lock(); err != nil {
+	if err := tc.rootManager.Lock(); err != nil {
 		tc.t.Errorf("Lock: unexpected error: %v", err)
 		return false
 	}
@@ -874,7 +880,7 @@ func testImportScript(tc *testContext) bool {
 	if !tc.watchingOnly {
 		err := walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 			ns := tx.ReadBucket(waddrmgrNamespaceKey)
-			return tc.manager.Unlock(ns, privPassphrase)
+			return tc.rootManager.Unlock(ns, privPassphrase)
 		})
 		if err != nil {
 			tc.t.Errorf("Unlock: unexpected error: %v", err)
@@ -973,7 +979,7 @@ func testImportScript(tc *testContext) bool {
 
 	// Lock the manager and retest all of the addresses to ensure the
 	// private information returns the expected error.
-	if err := tc.manager.Lock(); err != nil {
+	if err := tc.rootManager.Lock(); err != nil {
 		tc.t.Errorf("Lock: unexpected error: %v", err)
 		return false
 	}
@@ -1060,7 +1066,7 @@ func testMarkUsed(tc *testContext) bool {
 	return true
 }
 
-// testChangePassphrase ensures changes both the public and privte passphrases
+// testChangePassphrase ensures changes both the public and private passphrases
 // works as intended.
 func testChangePassphrase(tc *testContext) bool {
 	// Force an error when changing the passphrase due to failure to
@@ -1072,7 +1078,9 @@ func testChangePassphrase(tc *testContext) bool {
 	waddrmgr.TstRunWithReplacedNewSecretKey(func() {
 		err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-			return tc.manager.ChangePassphrase(ns, pubPassphrase, pubPassphrase2, false, fastScrypt)
+			return tc.rootManager.ChangePassphrase(
+				ns, pubPassphrase, pubPassphrase2, false, fastScrypt,
+			)
 		})
 	})
 	if !checkManagerError(tc.t, testName, err, waddrmgr.ErrCrypto) {
@@ -1083,7 +1091,9 @@ func testChangePassphrase(tc *testContext) bool {
 	testName = "ChangePassphrase (public) with invalid old passphrase"
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, []byte("bogus"), pubPassphrase2, false, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, []byte("bogus"), pubPassphrase2, false, fastScrypt,
+		)
 	})
 	if !checkManagerError(tc.t, testName, err, waddrmgr.ErrWrongPassphrase) {
 		return false
@@ -1093,7 +1103,9 @@ func testChangePassphrase(tc *testContext) bool {
 	testName = "ChangePassphrase (public)"
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, pubPassphrase, pubPassphrase2, false, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, pubPassphrase, pubPassphrase2, false, fastScrypt,
+		)
 	})
 	if err != nil {
 		tc.t.Errorf("%s: unexpected error: %v", testName, err)
@@ -1101,7 +1113,7 @@ func testChangePassphrase(tc *testContext) bool {
 	}
 
 	// Ensure the public passphrase was successfully changed.
-	if !tc.manager.TstCheckPublicPassphrase(pubPassphrase2) {
+	if !tc.rootManager.TstCheckPublicPassphrase(pubPassphrase2) {
 		tc.t.Errorf("%s: passphrase does not match", testName)
 		return false
 	}
@@ -1109,7 +1121,9 @@ func testChangePassphrase(tc *testContext) bool {
 	// Change the private passphrase back to what it was.
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, pubPassphrase2, pubPassphrase, false, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, pubPassphrase2, pubPassphrase, false, fastScrypt,
+		)
 	})
 	if err != nil {
 		tc.t.Errorf("%s: unexpected error: %v", testName, err)
@@ -1122,7 +1136,9 @@ func testChangePassphrase(tc *testContext) bool {
 	testName = "ChangePassphrase (private) with invalid old passphrase"
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, []byte("bogus"), privPassphrase2, true, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, []byte("bogus"), privPassphrase2, true, fastScrypt,
+		)
 	})
 	wantErrCode := waddrmgr.ErrWrongPassphrase
 	if tc.watchingOnly {
@@ -1144,7 +1160,9 @@ func testChangePassphrase(tc *testContext) bool {
 	testName = "ChangePassphrase (private)"
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, privPassphrase, privPassphrase2, true, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, privPassphrase, privPassphrase2, true, fastScrypt,
+		)
 	})
 	if err != nil {
 		tc.t.Errorf("%s: unexpected error: %v", testName, err)
@@ -1155,7 +1173,7 @@ func testChangePassphrase(tc *testContext) bool {
 	// expected.
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.Unlock(ns, privPassphrase2)
+		return tc.rootManager.Unlock(ns, privPassphrase2)
 	})
 	if err != nil {
 		tc.t.Errorf("%s: failed to unlock with new private "+
@@ -1168,19 +1186,21 @@ func testChangePassphrase(tc *testContext) bool {
 	// is unlocked to ensure that path works properly as well.
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.ChangePassphrase(ns, privPassphrase2, privPassphrase, true, fastScrypt)
+		return tc.rootManager.ChangePassphrase(
+			ns, privPassphrase2, privPassphrase, true, fastScrypt,
+		)
 	})
 	if err != nil {
 		tc.t.Errorf("%s: unexpected error: %v", testName, err)
 		return false
 	}
-	if tc.manager.IsLocked() {
+	if tc.rootManager.IsLocked() {
 		tc.t.Errorf("%s: manager is locked", testName)
 		return false
 	}
 
 	// Relock the manager for future tests.
-	if err := tc.manager.Lock(); err != nil {
+	if err := tc.rootManager.Lock(); err != nil {
 		tc.t.Errorf("Lock: unexpected error: %v", err)
 		return false
 	}
@@ -1221,7 +1241,7 @@ func testNewAccount(tc *testContext) bool {
 	// to derive account keys
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		err := tc.manager.Unlock(ns, privPassphrase)
+		err := tc.rootManager.Unlock(ns, privPassphrase)
 		return err
 	})
 	if err != nil {
@@ -1598,11 +1618,18 @@ func testWatchingOnly(tc *testContext) bool {
 	}
 
 	// Run all of the manager API tests against the converted manager and
-	// close it.
+	// close it. We'll also retrieve the default scope (BIP0044) from the
+	// manager in order to use.
+	scopedMgr, err := mgr.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0044)
+	if err != nil {
+		tc.t.Errorf("unable to fetch bip 44 scope %v", err)
+		return false
+	}
 	testManagerAPI(&testContext{
 		t:            tc.t,
 		db:           db,
-		manager:      mgr,
+		rootManager:  mgr,
+		manager:      scopedMgr,
 		account:      0,
 		create:       false,
 		watchingOnly: true,
@@ -1622,10 +1649,17 @@ func testWatchingOnly(tc *testContext) bool {
 	}
 	defer mgr.Close()
 
+	scopedMgr, err = mgr.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0044)
+	if err != nil {
+		tc.t.Errorf("unable to fetch bip 44 scope %v", err)
+		return false
+	}
+
 	testManagerAPI(&testContext{
 		t:            tc.t,
 		db:           db,
-		manager:      mgr,
+		rootManager:  mgr,
+		manager:      scopedMgr,
 		account:      0,
 		create:       false,
 		watchingOnly: true,
@@ -1636,261 +1670,47 @@ func testWatchingOnly(tc *testContext) bool {
 
 // testSync tests various facets of setting the manager sync state.
 func testSync(tc *testContext) bool {
-	tests := []struct {
-		name string
-		hash *chainhash.Hash
-	}{
-		{
-			name: "Block 1",
-			hash: newHash("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"),
-		},
-		{
-			name: "Block 2",
-			hash: newHash("000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd"),
-		},
-		{
-			name: "Block 3",
-			hash: newHash("0000000082b5015589a3fdf2d4baff403e6f0be035a5d9742c1cae6295464449"),
-		},
-		{
-			name: "Block 4",
-			hash: newHash("000000004ebadb55ee9096c9a2f8880e09da59c0d68b1c228da88e48844a1485"),
-		},
-		{
-			name: "Block 5",
-			hash: newHash("000000009b7262315dbf071787ad3656097b892abffd1f95a1a022f896f533fc"),
-		},
-		{
-			name: "Block 6",
-			hash: newHash("000000003031a0e73735690c5a1ff2a4be82553b2a12b776fbd3a215dc8f778d"),
-		},
-		{
-			name: "Block 7",
-			hash: newHash("0000000071966c2b1d065fd446b1e485b2c9d9594acd2007ccbd5441cfc89444"),
-		},
-		{
-			name: "Block 8",
-			hash: newHash("00000000408c48f847aa786c2268fc3e6ec2af68e8468a34a28c61b7f1de0dc6"),
-		},
-		{
-			name: "Block 9",
-			hash: newHash("000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805"),
-		},
-		{
-			name: "Block 10",
-			hash: newHash("000000002c05cc2e78923c34df87fd108b22221ac6076c18f3ade378a4d915e9"),
-		},
-		{
-			name: "Block 11",
-			hash: newHash("0000000097be56d606cdd9c54b04d4747e957d3608abe69198c661f2add73073"),
-		},
-		{
-			name: "Block 12",
-			hash: newHash("0000000027c2488e2510d1acf4369787784fa20ee084c258b58d9fbd43802b5e"),
-		},
-		{
-			name: "Block 13",
-			hash: newHash("000000005c51de2031a895adc145ee2242e919a01c6d61fb222a54a54b4d3089"),
-		},
-		{
-			name: "Block 14",
-			hash: newHash("0000000080f17a0c5a67f663a9bc9969eb37e81666d9321125f0e293656f8a37"),
-		},
-		{
-			name: "Block 15",
-			hash: newHash("00000000b3322c8c3ef7d2cf6da009a776e6a99ee65ec5a32f3f345712238473"),
-		},
-		{
-			name: "Block 16",
-			hash: newHash("00000000174a25bb399b009cc8deff1c4b3ea84df7e93affaaf60dc3416cc4f5"),
-		},
-		{
-			name: "Block 17",
-			hash: newHash("000000003ff1d0d70147acfbef5d6a87460ff5bcfce807c2d5b6f0a66bfdf809"),
-		},
-		{
-			name: "Block 18",
-			hash: newHash("000000008693e98cf893e4c85a446b410bb4dfa129bd1be582c09ed3f0261116"),
-		},
-		{
-			name: "Block 19",
-			hash: newHash("00000000841cb802ca97cf20fb9470480cae9e5daa5d06b4a18ae2d5dd7f186f"),
-		},
-		{
-			name: "Block 20",
-			hash: newHash("0000000067a97a2a37b8f190a17f0221e9c3f4fa824ddffdc2e205eae834c8d7"),
-		},
-		{
-			name: "Block 21",
-			hash: newHash("000000006f016342d1275be946166cff975c8b27542de70a7113ac6d1ef3294f"),
-		},
-	}
-
-	// Ensure there are enough test vectors to prove the maximum number of
-	// recent hashes is working properly.
-	maxRecentHashes := waddrmgr.TstMaxRecentHashes
-	if len(tests) < maxRecentHashes-1 {
-		tc.t.Errorf("Not enough hashes to test max recent hashes - "+
-			"need %d, have %d", maxRecentHashes-1, len(tests))
-		return false
-	}
-
-	for i, test := range tests {
-		blockStamp := waddrmgr.BlockStamp{
-			Height: int32(i) + 1,
-			Hash:   *test.hash,
-		}
-		err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-			return tc.manager.SetSyncedTo(ns, &blockStamp)
-		})
-		if err != nil {
-			tc.t.Errorf("SetSyncedTo unexpected err: %v", err)
-			return false
-		}
-
-		// Ensure the manager now claims it is synced to the block stamp
-		// that was just set.
-		gotBlockStamp := tc.manager.SyncedTo()
-		if gotBlockStamp != blockStamp {
-			tc.t.Errorf("SyncedTo unexpected block stamp -- got "+
-				"%v, want %v", gotBlockStamp, blockStamp)
-			return false
-		}
-
-		// Ensure the recent blocks iterator works properly.
-		j := 0
-		iter := tc.manager.NewIterateRecentBlocks()
-		for cont := iter != nil; cont; cont = iter.Prev() {
-			wantHeight := int32(i) - int32(j) + 1
-			var wantHash *chainhash.Hash
-			if wantHeight == 0 {
-				wantHash = chaincfg.MainNetParams.GenesisHash
-			} else {
-				wantHash = tests[wantHeight-1].hash
-			}
-
-			gotBS := iter.BlockStamp()
-			if gotBS.Height != wantHeight {
-				tc.t.Errorf("NewIterateRecentBlocks block "+
-					"stamp height mismatch -- got %d, "+
-					"want %d", gotBS.Height, wantHeight)
-				return false
-			}
-			if gotBS.Hash != *wantHash {
-				tc.t.Errorf("NewIterateRecentBlocks block "+
-					"stamp hash mismatch -- got %v, "+
-					"want %v", gotBS.Hash, wantHash)
-				return false
-			}
-			j++
-		}
-
-		// Ensure the maximum number of recent hashes works as expected.
-		if i >= maxRecentHashes-1 && j != maxRecentHashes {
-			tc.t.Errorf("NewIterateRecentBlocks iterated more than "+
-				"the max number of expected blocks -- got %d, "+
-				"want %d", j, maxRecentHashes)
-			return false
-		}
-	}
-
-	// Ensure rollback to block in recent history works as expected.
-	blockStamp := waddrmgr.BlockStamp{
-		Height: 10,
-		Hash:   *tests[9].hash,
-	}
-	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.SetSyncedTo(ns, &blockStamp)
-	})
-	if err != nil {
-		tc.t.Errorf("SetSyncedTo unexpected err on rollback to block "+
-			"in recent history: %v", err)
-		return false
-	}
-	gotBlockStamp := tc.manager.SyncedTo()
-	if gotBlockStamp != blockStamp {
-		tc.t.Errorf("SyncedTo unexpected block stamp on rollback -- "+
-			"got %v, want %v", gotBlockStamp, blockStamp)
-		return false
-	}
-
-	// Ensure syncing to a block that is in the future as compared to the
-	// current  block stamp clears the old recent blocks.
-	blockStamp = waddrmgr.BlockStamp{
-		Height: 100,
-		Hash:   *newHash("000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a"),
-	}
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.SetSyncedTo(ns, &blockStamp)
-	})
-	if err != nil {
-		tc.t.Errorf("SetSyncedTo unexpected err on future block stamp: "+
-			"%v", err)
-		return false
-	}
-	numRecentBlocks := 0
-	iter := tc.manager.NewIterateRecentBlocks()
-	for cont := iter != nil; cont; cont = iter.Prev() {
-		numRecentBlocks++
-	}
-	if numRecentBlocks != 1 {
-		tc.t.Errorf("Unexpected number of blocks after future block "+
-			"stamp -- got %d, want %d", numRecentBlocks, 1)
-		return false
-	}
-
-	// Rollback to a block that is not in the recent block history and
-	// ensure it results in only that block.
-	blockStamp = waddrmgr.BlockStamp{
-		Height: 1,
-		Hash:   *tests[0].hash,
-	}
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.SetSyncedTo(ns, &blockStamp)
-	})
-	if err != nil {
-		tc.t.Errorf("SetSyncedTo unexpected err on rollback to block "+
-			"not in recent history: %v", err)
-		return false
-	}
-	gotBlockStamp = tc.manager.SyncedTo()
-	if gotBlockStamp != blockStamp {
-		tc.t.Errorf("SyncedTo unexpected block stamp on rollback to "+
-			"block not in recent history -- got %v, want %v",
-			gotBlockStamp, blockStamp)
-		return false
-	}
-	numRecentBlocks = 0
-	iter = tc.manager.NewIterateRecentBlocks()
-	for cont := iter != nil; cont; cont = iter.Prev() {
-		numRecentBlocks++
-	}
-	if numRecentBlocks != 1 {
-		tc.t.Errorf("Unexpected number of blocks after rollback to "+
-			"block not in recent history -- got %d, want %d",
-			numRecentBlocks, 1)
-		return false
-	}
-
 	// Ensure syncing the manager to nil results in the synced to state
 	// being the earliest block (genesis block in this case).
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		return tc.manager.SetSyncedTo(ns, nil)
+		return tc.rootManager.SetSyncedTo(ns, nil)
 	})
 	if err != nil {
 		tc.t.Errorf("SetSyncedTo unexpected err on nil: %v", err)
 		return false
 	}
-	blockStamp = waddrmgr.BlockStamp{
+	blockStamp := waddrmgr.BlockStamp{
 		Height: 0,
 		Hash:   *chaincfg.MainNetParams.GenesisHash,
 	}
-	gotBlockStamp = tc.manager.SyncedTo()
+	gotBlockStamp := tc.rootManager.SyncedTo()
+	if gotBlockStamp != blockStamp {
+		tc.t.Errorf("SyncedTo unexpected block stamp on nil -- "+
+			"got %v, want %v", gotBlockStamp, blockStamp)
+		return false
+	}
+
+	// If we update to a new more recent block time stamp, then upon
+	// retrieval it should be returned as the best known state.
+	latestHash, err := chainhash.NewHash(seed)
+	if err != nil {
+		tc.t.Errorf("%v", err)
+		return false
+	}
+	blockStamp = waddrmgr.BlockStamp{
+		Height: 1,
+		Hash:   *latestHash,
+	}
+	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return tc.rootManager.SetSyncedTo(ns, &blockStamp)
+	})
+	if err != nil {
+		tc.t.Errorf("SetSyncedTo unexpected err on nil: %v", err)
+		return false
+	}
+	gotBlockStamp = tc.rootManager.SyncedTo()
 	if gotBlockStamp != blockStamp {
 		tc.t.Errorf("SyncedTo unexpected block stamp on nil -- "+
 			"got %v, want %v", gotBlockStamp, blockStamp)
@@ -1957,10 +1777,15 @@ func TestManager(t *testing.T) {
 
 	// Run all of the manager API tests in create mode and close the
 	// manager after they've completed
+	scopedMgr, err := mgr.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0044)
+	if err != nil {
+		t.Fatal("unable to fetch default scope: %v", err)
+	}
 	testManagerAPI(&testContext{
 		t:            t,
 		db:           db,
-		manager:      mgr,
+		manager:      scopedMgr,
+		rootManager:  mgr,
 		account:      0,
 		create:       true,
 		watchingOnly: false,
@@ -1994,10 +1819,15 @@ func TestManager(t *testing.T) {
 	}
 	defer mgr.Close()
 
+	scopedMgr, err = mgr.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0044)
+	if err != nil {
+		t.Fatal("unable to fetch default scope: %v", err)
+	}
 	tc := &testContext{
 		t:            t,
 		db:           db,
-		manager:      mgr,
+		manager:      scopedMgr,
+		rootManager:  mgr,
 		account:      0,
 		create:       false,
 		watchingOnly: false,

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1,0 +1,124 @@
+package waddrmgr
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/roasbeef/btcd/btcec"
+	"github.com/roasbeef/btcd/chaincfg"
+	"github.com/roasbeef/btcutil"
+	"github.com/roasbeef/btcutil/hdkeychain"
+	"github.com/roasbeef/btcwallet/internal/zero"
+	"github.com/roasbeef/btcwallet/walletdb"
+)
+
+// DerivationPath represents a derivation path from a particular key manager's
+// scope.  Each ScopedKeyManager starts key derivation from the end of their
+// cointype hardened key: m/purpose'/cointype'. The fields in this struct allow
+// further derivation to the next three child levels after the coin type key.
+// This restriction is in the spriti of BIP0044 type derivation. We maintain a
+// degree of coherency with the standard, but allow arbitrary derivations
+// beyond the cointype key. The key derived using this path will be exactly:
+// m/purpose'/cointype'/account/branch/index, where purpose' and cointype' are
+// bound by the scope of a particular manager.
+type DerivationPath struct {
+	// Account is the account, or the first immediate child from the scoped
+	// manager's hardened coin type key.
+	Account uint32
+
+	// Branch is the branch to be derived from the account index above. For
+	// BIP0044-like derivation, this is either 0 (external) or 1
+	// (internal). However, we allow this value to vary arbitrarily within
+	// its size range.
+	Branch uint32
+
+	// Index is the final child in the derivation path. This denotes the
+	// key index within as a child of the account and branch.
+	Index uint32
+}
+
+// KeyScope represents a restricted key scope from the primary root key within
+// the HD chain. From the root manager (m/) we can create a nearly arbitrary
+// number of ScopedKeyManagers of key derivation path: m/purpose'/cointype'.
+// These scoped managers can then me managed indecently, as they house the
+// encrypted cointype key and can derive any child keys from there on.
+type KeyScope struct {
+	// Purpose is the purpose of this key scope. This is the first child of
+	// the master HD key.
+	Purpose uint32
+
+	// Coin is a value that represents the particular coin which is the
+	// child of the purpose key. With this key, any accounts, or other
+	// children can be derived at all.
+	Coin uint32
+}
+
+// String returns a human readable version describing the keypath encapsulated
+// by the target key scope.
+func (k *KeyScope) String() string {
+	return fmt.Sprintf("m/%v'/%v'", k.Purpose, k.Coin)
+}
+
+// ScopeAddrSchema is the address schema of a particular KeyScope. This will be
+// persisted within the database, and will be consulted when deriving any keys
+// for a particular scope to know how to encode the public keys as addresses.
+type ScopeAddrSchema struct {
+	// ExternalAddrType is the address type for all keys within branch 0.
+	ExternalAddrType AddressType
+
+	// InternalAddrType is the address type for all keys within branch 1
+	// (change addresses).
+	InternalAddrType AddressType
+}
+
+var (
+	// KeyScopeBIP0049Plus is the key scope of our modified BIP0049
+	// derivation. We say this is BIP0049 "plus", as we'll actually use
+	// p2wkh change all change addresses.
+	KeyScopeBIP0049Plus = KeyScope{
+		Purpose: 49,
+		Coin:    0,
+	}
+
+	// KeyScopeBIP0084 is the key scope for BIP0084 derivation. BIP0084
+	// will be used to derive all p2wkh addresses.
+	KeyScopeBIP0084 = KeyScope{
+		Purpose: 84,
+		Coin:    0,
+	}
+
+	// KeyScopeBIP0044 is the key scope for BIP0044 derivation. Legacy
+	// wallets will only be able to use this key scope, and no keys beyond
+	// it.
+	KeyScopeBIP0044 = KeyScope{
+		Purpose: 44,
+		Coin:    0,
+	}
+
+	// DefaultKeyScopes is the set of default key scopes that will be
+	// created by the root manager upon initial creation.
+	DefaultKeyScopes = []KeyScope{
+		KeyScopeBIP0049Plus,
+		KeyScopeBIP0084,
+		KeyScopeBIP0044,
+	}
+
+	// ScopeAddrMap is a map from the default key scopes to the scope
+	// address schema for each scope type. This will be consulted during
+	// the initial creation of the root key manager.
+	ScopeAddrMap = map[KeyScope]ScopeAddrSchema{
+		KeyScopeBIP0049Plus: {
+			ExternalAddrType: NestedWitnessPubKey,
+			InternalAddrType: WitnessPubKey,
+		},
+		KeyScopeBIP0084: {
+			ExternalAddrType: WitnessPubKey,
+			InternalAddrType: WitnessPubKey,
+		},
+		KeyScopeBIP0044: {
+			InternalAddrType: PubKeyHash,
+			ExternalAddrType: PubKeyHash,
+		},
+	}
+)
+

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -122,3 +122,1364 @@ var (
 	}
 )
 
+// ScopedKeyManager is a sub key manager under the main root key manager. The
+// root key manager will handle the root HD key (m/), while each sub scoped key
+// manager will handle the cointype key for a particular key scope
+// (m/purpose'/cointype'). This abstraction allows higher-level applications
+// built upon the root key manager to perform their own arbitrary key
+// derivation, while still being protected under the encryption of the root key
+// manager.
+type ScopedKeyManager struct {
+	// scope is the scope of this key manager. We can only generate keys
+	// that are direct children of this scope.
+	scope KeyScope
+
+	// addrSchema is the address schema for this sub manager. This will be
+	// consulted when encoding addresses from derived keys.
+	addrSchema ScopeAddrSchema
+
+	// rootManager is a pointer to the root key manager. We'll maintain
+	// this as we need access to the crypto encryption keys before we can
+	// derive any new accounts of child keys of accounts.
+	rootManager *Manager
+
+	// addrs is a cached map of all the addresses that we currently
+	// manager.
+	addrs map[addrKey]ManagedAddress
+
+	// acctInfo houses information about accounts including what is needed
+	// to generate deterministic chained keys for each created account.
+	acctInfo map[uint32]*accountInfo
+
+	// deriveOnUnlock is a list of private keys which needs to be derived
+	// on the next unlock.  This occurs when a public address is derived
+	// while the address manager is locked since it does not have access to
+	// the private extended key (hence nor the underlying private key) in
+	// order to encrypt it.
+	deriveOnUnlock []*unlockDeriveInfo
+
+	mtx sync.RWMutex
+}
+
+// Scope returns the exact KeyScope of this scoped key manager.
+func (s *ScopedKeyManager) Scope() KeyScope {
+	return s.scope
+}
+
+// AddrSchema returns the set address schema for the target ScopedKeyManager.
+func (s *ScopedKeyManager) AddrSchema() ScopeAddrSchema {
+	return s.addrSchema
+}
+
+// zeroSensitivePublicData performs a best try effort to remove and zero all
+// sensitive public data associated with the address manager such as
+// hierarchical deterministic extended public keys and the crypto public keys.
+func (s *ScopedKeyManager) zeroSensitivePublicData() {
+	// Clear all of the account private keys.
+	for _, acctInfo := range s.acctInfo {
+		acctInfo.acctKeyPub.Zero()
+		acctInfo.acctKeyPub = nil
+	}
+}
+
+// Close cleanly shuts down the manager.  It makes a best try effort to remove
+// and zero all private key and sensitive public key material associated with
+// the address manager from memory.
+func (s *ScopedKeyManager) Close() {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Attempt to clear sensitive public key material from memory too.
+	s.zeroSensitivePublicData()
+	return
+}
+
+// keyToManaged returns a new managed address for the provided derived key and
+// its derivation path which consists of the account, branch, and index.
+//
+// The passed derivedKey is zeroed after the new address is created.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) keyToManaged(derivedKey *hdkeychain.ExtendedKey,
+	account, branch, index uint32) (ManagedAddress, error) {
+
+	var addrType AddressType
+	if branch == internalBranch {
+		addrType = s.addrSchema.InternalAddrType
+	} else {
+		addrType = s.addrSchema.ExternalAddrType
+	}
+
+	// Create a new managed address based on the public or private key
+	// depending on whether the passed key is private.  Also, zero the key
+	// after creating the managed address from it.
+	ma, err := newManagedAddressFromExtKey(
+		s, account, derivedKey, addrType,
+	)
+	defer derivedKey.Zero()
+	if err != nil {
+		return nil, err
+	}
+
+	if !derivedKey.IsPrivate() {
+		// Add the managed address to the list of addresses that need
+		// their private keys derived when the address manager is next
+		// unlocked.
+		info := unlockDeriveInfo{
+			managedAddr: ma,
+			branch:      branch,
+			index:       index,
+		}
+		s.deriveOnUnlock = append(s.deriveOnUnlock, &info)
+	}
+
+	if branch == internalBranch {
+		ma.internal = true
+	}
+
+	return ma, nil
+}
+
+// deriveKey returns either a public or private derived extended key based on
+// the private flag for the given an account info, branch, and index.
+func (s *ScopedKeyManager) deriveKey(acctInfo *accountInfo, branch,
+	index uint32, private bool) (*hdkeychain.ExtendedKey, error) {
+
+	// Choose the public or private extended key based on whether or not
+	// the private flag was specified.  This, in turn, allows for public or
+	// private child derivation.
+	acctKey := acctInfo.acctKeyPub
+	if private {
+		acctKey = acctInfo.acctKeyPriv
+	}
+
+	// Derive and return the key.
+	branchKey, err := acctKey.Child(branch)
+	if err != nil {
+		str := fmt.Sprintf("failed to derive extended key branch %d",
+			branch)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	addressKey, err := branchKey.Child(index)
+	branchKey.Zero() // Zero branch key after it's used.
+	if err != nil {
+		str := fmt.Sprintf("failed to derive child extended key -- "+
+			"branch %d, child %d",
+			branch, index)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	return addressKey, nil
+}
+
+// loadAccountInfo attempts to load and cache information about the given
+// account from the database.   This includes what is necessary to derive new
+// keys for it and track the state of the internal and external branches.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
+	account uint32) (*accountInfo, error) {
+
+	// Return the account info from cache if it's available.
+	if acctInfo, ok := s.acctInfo[account]; ok {
+		return acctInfo, nil
+	}
+
+	// The account is either invalid or just wasn't cached, so attempt to
+	// load the information from the database.
+	rowInterface, err := fetchAccountInfo(ns, &s.scope, account)
+	if err != nil {
+		return nil, maybeConvertDbError(err)
+	}
+
+	// Ensure the account type is a default account.
+	row, ok := rowInterface.(*dbDefaultAccountRow)
+	if !ok {
+		str := fmt.Sprintf("unsupported account type %T", row)
+		err = managerError(ErrDatabase, str, nil)
+	}
+
+	// Use the crypto public key to decrypt the account public extended
+	// key.
+	serializedKeyPub, err := s.rootManager.cryptoKeyPub.Decrypt(row.pubKeyEncrypted)
+	if err != nil {
+		str := fmt.Sprintf("failed to decrypt public key for account %d",
+			account)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+	acctKeyPub, err := hdkeychain.NewKeyFromString(string(serializedKeyPub))
+	if err != nil {
+		str := fmt.Sprintf("failed to create extended public key for "+
+			"account %d", account)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	// Create the new account info with the known information.  The rest of
+	// the fields are filled out below.
+	acctInfo := &accountInfo{
+		acctName:          row.name,
+		acctKeyEncrypted:  row.privKeyEncrypted,
+		acctKeyPub:        acctKeyPub,
+		nextExternalIndex: row.nextExternalIndex,
+		nextInternalIndex: row.nextInternalIndex,
+	}
+
+	if !s.rootManager.Locked() {
+		// Use the crypto private key to decrypt the account private
+		// extended keys.
+		decrypted, err := s.rootManager.cryptoKeyPriv.Decrypt(acctInfo.acctKeyEncrypted)
+		if err != nil {
+			str := fmt.Sprintf("failed to decrypt private key for "+
+				"account %d", account)
+			return nil, managerError(ErrCrypto, str, err)
+		}
+
+		acctKeyPriv, err := hdkeychain.NewKeyFromString(string(decrypted))
+		if err != nil {
+			str := fmt.Sprintf("failed to create extended private "+
+				"key for account %d", account)
+			return nil, managerError(ErrKeyChain, str, err)
+		}
+		acctInfo.acctKeyPriv = acctKeyPriv
+	}
+
+	// Derive and cache the managed address for the last external address.
+	branch, index := externalBranch, row.nextExternalIndex
+	if index > 0 {
+		index--
+	}
+	lastExtKey, err := s.deriveKey(
+		acctInfo, branch, index, !s.rootManager.Locked(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	lastExtAddr, err := s.keyToManaged(lastExtKey, account, branch, index)
+	if err != nil {
+		return nil, err
+	}
+	acctInfo.lastExternalAddr = lastExtAddr
+
+	// Derive and cache the managed address for the last internal address.
+	branch, index = internalBranch, row.nextInternalIndex
+	if index > 0 {
+		index--
+	}
+	lastIntKey, err := s.deriveKey(
+		acctInfo, branch, index, !s.rootManager.Locked(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	lastIntAddr, err := s.keyToManaged(lastIntKey, account, branch, index)
+	if err != nil {
+		return nil, err
+	}
+	acctInfo.lastInternalAddr = lastIntAddr
+
+	// Add it to the cache and return it when everything is successful.
+	s.acctInfo[account] = acctInfo
+	return acctInfo, nil
+}
+
+// AccountProperties returns properties associated with the account, such as
+// the account number, name, and the number of derived and imported keys.
+func (s *ScopedKeyManager) AccountProperties(ns walletdb.ReadBucket,
+	account uint32) (*AccountProperties, error) {
+
+	defer s.mtx.RUnlock()
+	s.mtx.RLock()
+
+	props := &AccountProperties{AccountNumber: account}
+
+	// Until keys can be imported into any account, special handling is
+	// required for the imported account.
+	//
+	// loadAccountInfo errors when using it on the imported account since
+	// the accountInfo struct is filled with a BIP0044 account's extended
+	// keys, and the imported accounts has none.
+	//
+	// Since only the imported account allows imports currently, the number
+	// of imported keys for any other account is zero, and since the
+	// imported account cannot contain non-imported keys, the external and
+	// internal key counts for it are zero.
+	if account != ImportedAddrAccount {
+		acctInfo, err := s.loadAccountInfo(ns, account)
+		if err != nil {
+			return nil, err
+		}
+		props.AccountName = acctInfo.acctName
+		props.ExternalKeyCount = acctInfo.nextExternalIndex
+		props.InternalKeyCount = acctInfo.nextInternalIndex
+	} else {
+		props.AccountName = ImportedAddrAccountName // reserved, nonchangable
+
+		// Could be more efficient if this was tracked by the db.
+		var importedKeyCount uint32
+		count := func(interface{}) error {
+			importedKeyCount++
+			return nil
+		}
+		err := forEachAccountAddress(ns, &s.scope, ImportedAddrAccount, count)
+		if err != nil {
+			return nil, err
+		}
+		props.ImportedKeyCount = importedKeyCount
+	}
+
+	return props, nil
+}
+
+// DeriveFromKeyPath attempts to derive a maximal child key (under the BIP0044
+// scheme) from a given key path. If key derivation isn't possible, then an
+// error will be returned.
+func (s *ScopedKeyManager) DeriveFromKeyPath(ns walletdb.ReadBucket,
+	kp DerivationPath) (ManagedAddress, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	extKey, err := s.deriveKeyFromPath(
+		ns, kp.Account, kp.Branch, kp.Index, !s.rootManager.Locked(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.keyToManaged(extKey, kp.Account, kp.Branch, kp.Index)
+}
+
+// deriveKeyFromPath returns either a public or private derived extended key
+// based on the private flag for the given an account, branch, and index.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) deriveKeyFromPath(ns walletdb.ReadBucket, account, branch,
+	index uint32, private bool) (*hdkeychain.ExtendedKey, error) {
+
+	// Look up the account key information.
+	acctInfo, err := s.loadAccountInfo(ns, account)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.deriveKey(acctInfo, branch, index, private)
+}
+
+// chainAddressRowToManaged returns a new managed address based on chained
+// address data loaded from the database.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) chainAddressRowToManaged(ns walletdb.ReadBucket,
+	row *dbChainAddressRow) (ManagedAddress, error) {
+
+	addressKey, err := s.deriveKeyFromPath(
+		ns, row.account, row.branch, row.index, !s.rootManager.Locked(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.keyToManaged(addressKey, row.account, row.branch, row.index)
+}
+
+// importedAddressRowToManaged returns a new managed address based on imported
+// address data loaded from the database.
+func (s *ScopedKeyManager) importedAddressRowToManaged(row *dbImportedAddressRow) (ManagedAddress, error) {
+
+	// Use the crypto public key to decrypt the imported public key.
+	pubBytes, err := s.rootManager.cryptoKeyPub.Decrypt(row.encryptedPubKey)
+	if err != nil {
+		str := "failed to decrypt public key for imported address"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	pubKey, err := btcec.ParsePubKey(pubBytes, btcec.S256())
+	if err != nil {
+		str := "invalid public key for imported address"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	compressed := len(pubBytes) == btcec.PubKeyBytesLenCompressed
+	ma, err := newManagedAddressWithoutPrivKey(
+		s, row.account, pubKey, compressed,
+		s.addrSchema.ExternalAddrType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	ma.privKeyEncrypted = row.encryptedPrivKey
+	ma.imported = true
+
+	return ma, nil
+}
+
+// scriptAddressRowToManaged returns a new managed address based on script
+// address data loaded from the database.
+func (s *ScopedKeyManager) scriptAddressRowToManaged(row *dbScriptAddressRow) (ManagedAddress, error) {
+	// Use the crypto public key to decrypt the imported script hash.
+	scriptHash, err := s.rootManager.cryptoKeyPub.Decrypt(row.encryptedHash)
+	if err != nil {
+		str := "failed to decrypt imported script hash"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	return newScriptAddress(s, row.account, scriptHash, row.encryptedScript)
+}
+
+// rowInterfaceToManaged returns a new managed address based on the given
+// address data loaded from the database.  It will automatically select the
+// appropriate type.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) rowInterfaceToManaged(ns walletdb.ReadBucket,
+	rowInterface interface{}) (ManagedAddress, error) {
+
+	switch row := rowInterface.(type) {
+	case *dbChainAddressRow:
+		return s.chainAddressRowToManaged(ns, row)
+
+	case *dbImportedAddressRow:
+		return s.importedAddressRowToManaged(row)
+
+	case *dbScriptAddressRow:
+		return s.scriptAddressRowToManaged(row)
+	}
+
+	str := fmt.Sprintf("unsupported address type %T", rowInterface)
+	return nil, managerError(ErrDatabase, str, nil)
+}
+
+// loadAndCacheAddress attempts to load the passed address from the database
+// and caches the associated managed address.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) loadAndCacheAddress(ns walletdb.ReadBucket,
+	address btcutil.Address) (ManagedAddress, error) {
+
+	// Attempt to load the raw address information from the database.
+	rowInterface, err := fetchAddress(ns, &s.scope, address.ScriptAddress())
+	if err != nil {
+		if merr, ok := err.(*ManagerError); ok {
+			desc := fmt.Sprintf("failed to fetch address '%s': %v",
+				address.ScriptAddress(), merr.Description)
+			merr.Description = desc
+			return nil, merr
+		}
+		return nil, maybeConvertDbError(err)
+	}
+
+	// Create a new managed address for the specific type of address based
+	// on type.
+	managedAddr, err := s.rowInterfaceToManaged(ns, rowInterface)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache and return the new managed address.
+	s.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
+
+	return managedAddr, nil
+}
+
+// existsAddress returns whether or not the passed address is known to the
+// address manager.
+//
+// This function MUST be called with the manager lock held for reads.
+func (s *ScopedKeyManager) existsAddress(ns walletdb.ReadBucket, addressID []byte) bool {
+	// Check the in-memory map first since it's faster than a db access.
+	if _, ok := s.addrs[addrKey(addressID)]; ok {
+		return true
+	}
+
+	// Check the database if not already found above.
+	return existsAddress(ns, &s.scope, addressID)
+}
+
+// Address returns a managed address given the passed address if it is known to
+// the address manager.  A managed address differs from the passed address in
+// that it also potentially contains extra information needed to sign
+// transactions such as the associated private key for pay-to-pubkey and
+// pay-to-pubkey-hash addresses and the script associated with
+// pay-to-script-hash addresses.
+func (s *ScopedKeyManager) Address(ns walletdb.ReadBucket,
+	address btcutil.Address) (ManagedAddress, error) {
+
+	// ScriptAddress will only return a script hash if we're accessing an
+	// address that is either PKH or SH. In the event we're passed a PK
+	// address, convert the PK to PKH address so that we can access it from
+	// the addrs map and database.
+	if pka, ok := address.(*btcutil.AddressPubKey); ok {
+		address = pka.AddressPubKeyHash()
+	}
+
+	// Return the address from cache if it's available.
+	//
+	// NOTE: Not using a defer on the lock here since a write lock is
+	// needed if the lookup fails.
+	s.mtx.RLock()
+	if ma, ok := s.addrs[addrKey(address.ScriptAddress())]; ok {
+		s.mtx.RUnlock()
+		return ma, nil
+	}
+	s.mtx.RUnlock()
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Attempt to load the address from the database.
+	return s.loadAndCacheAddress(ns, address)
+}
+
+// AddrAccount returns the account to which the given address belongs.
+func (s *ScopedKeyManager) AddrAccount(ns walletdb.ReadBucket,
+	address btcutil.Address) (uint32, error) {
+
+	account, err := fetchAddrAccount(ns, &s.scope, address.ScriptAddress())
+	if err != nil {
+		return 0, maybeConvertDbError(err)
+	}
+
+	return account, nil
+}
+
+// nextAddresses returns the specified number of next chained address from the
+// branch indicated by the internal flag.
+//
+// This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
+	account uint32, numAddresses uint32, internal bool) ([]ManagedAddress, error) {
+
+	// The next address can only be generated for accounts that have
+	// already been created.
+	acctInfo, err := s.loadAccountInfo(ns, account)
+	if err != nil {
+		return nil, err
+	}
+
+	// Choose the account key to used based on whether the address manager
+	// is locked.
+	acctKey := acctInfo.acctKeyPub
+	if !s.rootManager.Locked() {
+		acctKey = acctInfo.acctKeyPriv
+	}
+
+	// Choose the branch key and index depending on whether or not this is
+	// an internal address.
+	branchNum, nextIndex := externalBranch, acctInfo.nextExternalIndex
+	if internal {
+		branchNum = internalBranch
+		nextIndex = acctInfo.nextInternalIndex
+	}
+
+	addrType := s.addrSchema.ExternalAddrType
+	if internal {
+		addrType = s.addrSchema.InternalAddrType
+	}
+
+	// Ensure the requested number of addresses doesn't exceed the maximum
+	// allowed for this account.
+	if numAddresses > MaxAddressesPerAccount || nextIndex+numAddresses >
+		MaxAddressesPerAccount {
+		str := fmt.Sprintf("%d new addresses would exceed the maximum "+
+			"allowed number of addresses per account of %d",
+			numAddresses, MaxAddressesPerAccount)
+		return nil, managerError(ErrTooManyAddresses, str, nil)
+	}
+
+	// Derive the appropriate branch key and ensure it is zeroed when done.
+	branchKey, err := acctKey.Child(branchNum)
+	if err != nil {
+		str := fmt.Sprintf("failed to derive extended key branch %d",
+			branchNum)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+	defer branchKey.Zero() // Ensure branch key is zeroed when done.
+
+	// Create the requested number of addresses and keep track of the index
+	// with each one.
+	addressInfo := make([]*unlockDeriveInfo, 0, numAddresses)
+	for i := uint32(0); i < numAddresses; i++ {
+		// There is an extremely small chance that a particular child is
+		// invalid, so use a loop to derive the next valid child.
+		var nextKey *hdkeychain.ExtendedKey
+		for {
+			// Derive the next child in the external chain branch.
+			key, err := branchKey.Child(nextIndex)
+			if err != nil {
+				// When this particular child is invalid, skip to the
+				// next index.
+				if err == hdkeychain.ErrInvalidChild {
+					nextIndex++
+					continue
+				}
+
+				str := fmt.Sprintf("failed to generate child %d",
+					nextIndex)
+				return nil, managerError(ErrKeyChain, str, err)
+			}
+			key.SetNet(s.rootManager.chainParams)
+
+			nextIndex++
+			nextKey = key
+			break
+		}
+
+		// Create a new managed address based on the public or private
+		// key depending on whether the generated key is private.
+		// Also, zero the next key after creating the managed address
+		// from it.
+		addr, err := newManagedAddressFromExtKey(
+			s, account, nextKey, addrType,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if internal {
+			addr.internal = true
+		}
+		managedAddr := addr
+		nextKey.Zero()
+
+		info := unlockDeriveInfo{
+			managedAddr: managedAddr,
+			branch:      branchNum,
+			index:       nextIndex - 1,
+		}
+		addressInfo = append(addressInfo, &info)
+	}
+
+	// Now that all addresses have been successfully generated, update the
+	// database in a single transaction.
+	for _, info := range addressInfo {
+		ma := info.managedAddr
+		addressID := ma.Address().ScriptAddress()
+
+		switch a := ma.(type) {
+		case *managedAddress:
+			err := putChainedAddress(
+				ns, &s.scope, addressID, account, ssFull,
+				info.branch, info.index, adtChain,
+			)
+			if err != nil {
+				return nil, maybeConvertDbError(err)
+			}
+		case *scriptAddress:
+			encryptedHash, err := s.rootManager.cryptoKeyPub.Encrypt(a.AddrHash())
+			if err != nil {
+				str := fmt.Sprintf("failed to encrypt script hash %x",
+					a.AddrHash())
+				return nil, managerError(ErrCrypto, str, err)
+			}
+
+			err = putScriptAddress(
+				ns, &s.scope, a.AddrHash(), ImportedAddrAccount,
+				ssNone, encryptedHash, a.scriptEncrypted,
+			)
+			if err != nil {
+				return nil, maybeConvertDbError(err)
+			}
+		}
+	}
+
+	// Finally update the next address tracking and add the addresses to
+	// the cache after the newly generated addresses have been successfully
+	// added to the db.
+	managedAddresses := make([]ManagedAddress, 0, len(addressInfo))
+	for _, info := range addressInfo {
+		ma := info.managedAddr
+		s.addrs[addrKey(ma.Address().ScriptAddress())] = ma
+
+		// Add the new managed address to the list of addresses that
+		// need their private keys derived when the address manager is
+		// next unlocked.
+		if s.rootManager.Locked() && !s.rootManager.WatchOnly() {
+			s.deriveOnUnlock = append(s.deriveOnUnlock, info)
+		}
+
+		managedAddresses = append(managedAddresses, ma)
+	}
+
+	// Set the last address and next address for tracking.
+	ma := addressInfo[len(addressInfo)-1].managedAddr
+	if internal {
+		acctInfo.nextInternalIndex = nextIndex
+		acctInfo.lastInternalAddr = ma
+	} else {
+		acctInfo.nextExternalIndex = nextIndex
+		acctInfo.lastExternalAddr = ma
+	}
+
+	return managedAddresses, nil
+}
+
+// NextExternalAddresses returns the specified number of next chained addresses
+// that are intended for external use from the address manager.
+func (s *ScopedKeyManager) NextExternalAddresses(ns walletdb.ReadWriteBucket,
+	account uint32, numAddresses uint32) ([]ManagedAddress, error) {
+
+	// Enforce maximum account number.
+	if account > MaxAccountNum {
+		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	return s.nextAddresses(ns, account, numAddresses, false)
+}
+
+// NextInternalAddresses returns the specified number of next chained addresses
+// that are intended for internal use such as change from the address manager.
+func (s *ScopedKeyManager) NextInternalAddresses(ns walletdb.ReadWriteBucket,
+	account uint32, numAddresses uint32) ([]ManagedAddress, error) {
+
+	// Enforce maximum account number.
+	if account > MaxAccountNum {
+		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	return s.nextAddresses(ns, account, numAddresses, true)
+}
+
+// LastExternalAddress returns the most recently requested chained external
+// address from calling NextExternalAddress for the given account.  The first
+// external address for the account will be returned if none have been
+// previously requested.
+//
+// This function will return an error if the provided account number is greater
+// than the MaxAccountNum constant or there is no account information for the
+// passed account.  Any other errors returned are generally unexpected.
+func (s *ScopedKeyManager) LastExternalAddress(ns walletdb.ReadBucket,
+	account uint32) (ManagedAddress, error) {
+
+	// Enforce maximum account number.
+	if account > MaxAccountNum {
+		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Load account information for the passed account.  It is typically
+	// cached, but if not it will be loaded from the database.
+	acctInfo, err := s.loadAccountInfo(ns, account)
+	if err != nil {
+		return nil, err
+	}
+
+	if acctInfo.nextExternalIndex > 0 {
+		return acctInfo.lastExternalAddr, nil
+	}
+
+	return nil, managerError(ErrAddressNotFound, "no previous external address", nil)
+}
+
+// LastInternalAddress returns the most recently requested chained internal
+// address from calling NextInternalAddress for the given account.  The first
+// internal address for the account will be returned if none have been
+// previously requested.
+//
+// This function will return an error if the provided account number is greater
+// than the MaxAccountNum constant or there is no account information for the
+// passed account.  Any other errors returned are generally unexpected.
+func (s *ScopedKeyManager) LastInternalAddress(ns walletdb.ReadBucket,
+	account uint32) (ManagedAddress, error) {
+
+	// Enforce maximum account number.
+	if account > MaxAccountNum {
+		err := managerError(ErrAccountNumTooHigh, errAcctTooHigh, nil)
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Load account information for the passed account.  It is typically
+	// cached, but if not it will be loaded from the database.
+	acctInfo, err := s.loadAccountInfo(ns, account)
+	if err != nil {
+		return nil, err
+	}
+
+	if acctInfo.nextInternalIndex > 0 {
+		return acctInfo.lastInternalAddr, nil
+	}
+
+	return nil, managerError(ErrAddressNotFound, "no previous internal address", nil)
+}
+
+// NewRawAccount creates a new account for the scoped manager. This method
+// differs from the NewAccount method in that this method takes the acount
+// number *directly*, rather than taking a string name for the account, then
+// mapping that to the next highest account number.
+func (s *ScopedKeyManager) NewRawAccount(ns walletdb.ReadWriteBucket, number uint32) error {
+	if s.rootManager.WatchOnly() {
+		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.rootManager.Locked() {
+		return managerError(ErrLocked, errLocked, nil)
+	}
+
+	// As this is an ad hoc account that may not follow our normal linear
+	// derivation, we'll create a new name for this account based off of
+	// the account number.
+	name := fmt.Sprintf("act:%v", number)
+	return s.newAccount(ns, number, name)
+}
+
+// NewAccount creates and returns a new account stored in the manager based on
+// the given account name.  If an account with the same name already exists,
+// ErrDuplicateAccount will be returned.  Since creating a new account requires
+// access to the cointype keys (from which extended account keys are derived),
+// it requires the manager to be unlocked.
+func (s *ScopedKeyManager) NewAccount(ns walletdb.ReadWriteBucket, name string) (uint32, error) {
+	if s.rootManager.WatchOnly() {
+		return 0, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.rootManager.Locked() {
+		return 0, managerError(ErrLocked, errLocked, nil)
+	}
+
+	// Fetch latest account, and create a new account in the same
+	// transaction Fetch the latest account number to generate the next
+	// account number
+	account, err := fetchLastAccount(ns, &s.scope)
+	if err != nil {
+		return 0, err
+	}
+	account++
+
+	// With the name validated, we'll create a new account for the new
+	// contiguous account.
+	if err := s.newAccount(ns, account, name); err != nil {
+		return 0, err
+	}
+
+	return account, nil
+}
+
+// newAccount is a helper function that derives a new precise account number,
+// and creates a mapping from the passed name to the account number in the
+// database.
+//
+// NOTE: This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
+	account uint32, name string) error {
+
+	// Validate the account name.
+	if err := ValidateAccountName(name); err != nil {
+		return err
+	}
+
+	// Check that account with the same name does not exist
+	_, err := s.lookupAccount(ns, name)
+	if err == nil {
+		str := fmt.Sprintf("account with the same name already exists")
+		return managerError(ErrDuplicateAccount, str, err)
+	}
+
+	// Fetch the cointype key which will be used to derive the next account
+	// extended keys
+	_, coinTypePrivEnc, err := fetchCoinTypeKeys(ns, &s.scope)
+	if err != nil {
+		return err
+	}
+
+	// Decrypt the cointype key.
+	serializedKeyPriv, err := s.rootManager.cryptoKeyPriv.Decrypt(coinTypePrivEnc)
+	if err != nil {
+		str := fmt.Sprintf("failed to decrypt cointype serialized private key")
+		return managerError(ErrLocked, str, err)
+	}
+	coinTypeKeyPriv, err := hdkeychain.NewKeyFromString(string(serializedKeyPriv))
+	zero.Bytes(serializedKeyPriv)
+	if err != nil {
+		str := fmt.Sprintf("failed to create cointype extended private key")
+		return managerError(ErrKeyChain, str, err)
+	}
+
+	// Derive the account key using the cointype key
+	acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, account)
+	coinTypeKeyPriv.Zero()
+	if err != nil {
+		str := "failed to convert private key for account"
+		return managerError(ErrKeyChain, str, err)
+	}
+	acctKeyPub, err := acctKeyPriv.Neuter()
+	if err != nil {
+		str := "failed to convert public key for account"
+		return managerError(ErrKeyChain, str, err)
+	}
+
+	// Encrypt the default account keys with the associated crypto keys.
+	acctPubEnc, err := s.rootManager.cryptoKeyPub.Encrypt(
+		[]byte(acctKeyPub.String()),
+	)
+	if err != nil {
+		str := "failed to  encrypt public key for account"
+		return managerError(ErrCrypto, str, err)
+	}
+	acctPrivEnc, err := s.rootManager.cryptoKeyPriv.Encrypt(
+		[]byte(acctKeyPriv.String()),
+	)
+	if err != nil {
+		str := "failed to encrypt private key for account"
+		return managerError(ErrCrypto, str, err)
+	}
+
+	// We have the encrypted account extended keys, so save them to the
+	// database
+	err = putAccountInfo(
+		ns, &s.scope, account, acctPubEnc, acctPrivEnc, 0, 0, name,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Save last account metadata
+	return putLastAccount(ns, &s.scope, account)
+}
+
+// RenameAccount renames an account stored in the manager based on the given
+// account number with the given name.  If an account with the same name
+// already exists, ErrDuplicateAccount will be returned.
+func (s *ScopedKeyManager) RenameAccount(ns walletdb.ReadWriteBucket,
+	account uint32, name string) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Ensure that a reserved account is not being renamed.
+	if isReservedAccountNum(account) {
+		str := "reserved account cannot be renamed"
+		return managerError(ErrInvalidAccount, str, nil)
+	}
+
+	// Check that account with the new name does not exist
+	_, err := s.lookupAccount(ns, name)
+	if err == nil {
+		str := fmt.Sprintf("account with the same name already exists")
+		return managerError(ErrDuplicateAccount, str, err)
+	}
+
+	// Validate account name
+	if err := ValidateAccountName(name); err != nil {
+		return err
+	}
+
+	rowInterface, err := fetchAccountInfo(ns, &s.scope, account)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the account type is a default account.
+	row, ok := rowInterface.(*dbDefaultAccountRow)
+	if !ok {
+		str := fmt.Sprintf("unsupported account type %T", row)
+		err = managerError(ErrDatabase, str, nil)
+	}
+
+	// Remove the old name key from the account id index.
+	if err = deleteAccountIDIndex(ns, &s.scope, account); err != nil {
+		return err
+	}
+
+	// Remove the old name key from the account name index.
+	if err = deleteAccountNameIndex(ns, &s.scope, row.name); err != nil {
+		return err
+	}
+	err = putAccountInfo(
+		ns, &s.scope, account, row.pubKeyEncrypted,
+		row.privKeyEncrypted, row.nextExternalIndex,
+		row.nextInternalIndex, name,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Update in-memory account info with new name if cached and the db
+	// write was successful.
+	if err == nil {
+		if acctInfo, ok := s.acctInfo[account]; ok {
+			acctInfo.acctName = name
+		}
+	}
+
+	return err
+}
+
+// ImportPrivateKey imports a WIF private key into the address manager.  The
+// imported address is created using either a compressed or uncompressed
+// serialized public key, depending on the CompressPubKey bool of the WIF.
+//
+// All imported addresses will be part of the account defined by the
+// ImportedAddrAccount constant.
+//
+// NOTE: When the address manager is watching-only, the private key itself will
+// not be stored or available since it is private data.  Instead, only the
+// public key will be stored.  This means it is paramount the private key is
+// kept elsewhere as the watching-only address manager will NOT ever have access
+// to it.
+//
+// This function will return an error if the address manager is locked and not
+// watching-only, or not for the same network as the key trying to be imported.
+// It will also return an error if the address already exists.  Any other
+// errors returned are generally unexpected.
+func (s *ScopedKeyManager) ImportPrivateKey(ns walletdb.ReadWriteBucket,
+	wif *btcutil.WIF, bs *BlockStamp) (ManagedPubKeyAddress, error) {
+
+	// Ensure the address is intended for network the address manager is
+	// associated with.
+	if !wif.IsForNet(s.rootManager.chainParams) {
+		str := fmt.Sprintf("private key is not for the same network the "+
+			"address manager is configured for (%s)",
+			s.rootManager.chainParams.Name)
+		return nil, managerError(ErrWrongNet, str, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// The manager must be unlocked to encrypt the imported private key.
+	if s.rootManager.Locked() && !s.rootManager.WatchOnly() {
+		return nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	// Prevent duplicates.
+	serializedPubKey := wif.SerializePubKey()
+	pubKeyHash := btcutil.Hash160(serializedPubKey)
+	alreadyExists := s.existsAddress(ns, pubKeyHash)
+	if alreadyExists {
+		str := fmt.Sprintf("address for public key %x already exists",
+			serializedPubKey)
+		return nil, managerError(ErrDuplicateAddress, str, nil)
+	}
+
+	// Encrypt public key.
+	encryptedPubKey, err := s.rootManager.cryptoKeyPub.Encrypt(
+		serializedPubKey,
+	)
+	if err != nil {
+		str := fmt.Sprintf("failed to encrypt public key for %x",
+			serializedPubKey)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	// Encrypt the private key when not a watching-only address manager.
+	var encryptedPrivKey []byte
+	if !s.rootManager.WatchOnly() {
+		privKeyBytes := wif.PrivKey.Serialize()
+		encryptedPrivKey, err = s.rootManager.cryptoKeyPriv.Encrypt(privKeyBytes)
+		zero.Bytes(privKeyBytes)
+		if err != nil {
+			str := fmt.Sprintf("failed to encrypt private key for %x",
+				serializedPubKey)
+			return nil, managerError(ErrCrypto, str, err)
+		}
+	}
+
+	// The start block needs to be updated when the newly imported address
+	// is before the current one.
+	s.rootManager.mtx.Lock()
+	updateStartBlock := bs.Height < s.rootManager.syncState.startBlock.Height
+	s.rootManager.mtx.Unlock()
+
+	// Save the new imported address to the db and update start block (if
+	// needed) in a single transaction.
+	err = putImportedAddress(
+		ns, &s.scope, pubKeyHash, ImportedAddrAccount, ssNone,
+		encryptedPubKey, encryptedPrivKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if updateStartBlock {
+		err := putStartBlock(ns, bs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Now that the database has been updated, update the start block in
+	// memory too if needed.
+	if updateStartBlock {
+		s.rootManager.mtx.Lock()
+		s.rootManager.syncState.startBlock = *bs
+		s.rootManager.mtx.Unlock()
+	}
+
+	// Create a new managed address based on the imported address.
+	var managedAddr *managedAddress
+	if !s.rootManager.WatchOnly() {
+		managedAddr, err = newManagedAddress(
+			s, ImportedAddrAccount, wif.PrivKey,
+			wif.CompressPubKey, s.addrSchema.ExternalAddrType,
+		)
+	} else {
+		pubKey := (*btcec.PublicKey)(&wif.PrivKey.PublicKey)
+		managedAddr, err = newManagedAddressWithoutPrivKey(
+			s, ImportedAddrAccount, pubKey, wif.CompressPubKey,
+			s.addrSchema.ExternalAddrType,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	managedAddr.imported = true
+
+	// Add the new managed address to the cache of recent addresses and
+	// return it.
+	s.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
+	return managedAddr, nil
+}
+
+// ImportScript imports a user-provided script into the address manager.  The
+// imported script will act as a pay-to-script-hash address.
+//
+// All imported script addresses will be part of the account defined by the
+// ImportedAddrAccount constant.
+//
+// When the address manager is watching-only, the script itself will not be
+// stored or available since it is considered private data.
+//
+// This function will return an error if the address manager is locked and not
+// watching-only, or the address already exists.  Any other errors returned are
+// generally unexpected.
+func (s *ScopedKeyManager) ImportScript(ns walletdb.ReadWriteBucket,
+	script []byte, bs *BlockStamp) (ManagedScriptAddress, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// The manager must be unlocked to encrypt the imported script.
+	if s.rootManager.Locked() && !s.rootManager.WatchOnly() {
+		return nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	// Prevent duplicates.
+	scriptHash := btcutil.Hash160(script)
+	alreadyExists := s.existsAddress(ns, scriptHash)
+	if alreadyExists {
+		str := fmt.Sprintf("address for script hash %x already exists",
+			scriptHash)
+		return nil, managerError(ErrDuplicateAddress, str, nil)
+	}
+
+	// Encrypt the script hash using the crypto public key so it is
+	// accessible when the address manager is locked or watching-only.
+	encryptedHash, err := s.rootManager.cryptoKeyPub.Encrypt(scriptHash)
+	if err != nil {
+		str := fmt.Sprintf("failed to encrypt script hash %x",
+			scriptHash)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	// Encrypt the script for storage in database using the crypto script
+	// key when not a watching-only address manager.
+	var encryptedScript []byte
+	if !s.rootManager.WatchOnly() {
+		encryptedScript, err = s.rootManager.cryptoKeyScript.Encrypt(
+			script,
+		)
+		if err != nil {
+			str := fmt.Sprintf("failed to encrypt script for %x",
+				scriptHash)
+			return nil, managerError(ErrCrypto, str, err)
+		}
+	}
+
+	// The start block needs to be updated when the newly imported address
+	// is before the current one.
+	updateStartBlock := false
+	s.rootManager.mtx.Lock()
+	if bs.Height < s.rootManager.syncState.startBlock.Height {
+		updateStartBlock = true
+	}
+	s.rootManager.mtx.Unlock()
+
+	// Save the new imported address to the db and update start block (if
+	// needed) in a single transaction.
+	err = putScriptAddress(
+		ns, &s.scope, scriptHash, ImportedAddrAccount, ssNone,
+		encryptedHash, encryptedScript,
+	)
+	if err != nil {
+		return nil, maybeConvertDbError(err)
+	}
+
+	if updateStartBlock {
+		err := putStartBlock(ns, bs)
+		if err != nil {
+			return nil, maybeConvertDbError(err)
+		}
+	}
+
+	// Now that the database has been updated, update the start block in
+	// memory too if needed.
+	if updateStartBlock {
+		s.rootManager.mtx.Lock()
+		s.rootManager.syncState.startBlock = *bs
+		s.rootManager.mtx.Unlock()
+	}
+
+	// Create a new managed address based on the imported script.  Also,
+	// when not a watching-only address manager, make a copy of the script
+	// since it will be cleared on lock and the script the caller passed
+	// should not be cleared out from under the caller.
+	scriptAddr, err := newScriptAddress(
+		s, ImportedAddrAccount, scriptHash, encryptedScript,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !s.rootManager.WatchOnly() {
+		scriptAddr.scriptCT = make([]byte, len(script))
+		copy(scriptAddr.scriptCT, script)
+	}
+
+	// Add the new managed address to the cache of recent addresses and
+	// return it.
+	s.addrs[addrKey(scriptHash)] = scriptAddr
+	return scriptAddr, nil
+}
+
+// lookupAccount loads account number stored in the manager for the given
+// account name
+//
+// This function MUST be called with the manager lock held for reads.
+func (s *ScopedKeyManager) lookupAccount(ns walletdb.ReadBucket, name string) (uint32, error) {
+	return fetchAccountByName(ns, &s.scope, name)
+}
+
+// LookupAccount loads account number stored in the manager for the given
+// account name
+func (s *ScopedKeyManager) LookupAccount(ns walletdb.ReadBucket, name string) (uint32, error) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	return s.lookupAccount(ns, name)
+}
+
+// fetchUsed returns true if the provided address id was flagged used.
+func (s *ScopedKeyManager) fetchUsed(ns walletdb.ReadBucket,
+	addressID []byte) bool {
+
+	return fetchAddressUsed(ns, &s.scope, addressID)
+}
+
+// MarkUsed updates the used flag for the provided address.
+func (s *ScopedKeyManager) MarkUsed(ns walletdb.ReadWriteBucket,
+	address btcutil.Address) error {
+
+	addressID := address.ScriptAddress()
+	err := markAddressUsed(ns, &s.scope, addressID)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	// Clear caches which might have stale entries for used addresses
+	s.mtx.Lock()
+	delete(s.addrs, addrKey(addressID))
+	s.mtx.Unlock()
+	return nil
+}
+
+// ChainParams returns the chain parameters for this address manager.
+func (s *ScopedKeyManager) ChainParams() *chaincfg.Params {
+	// NOTE: No need for mutex here since the net field does not change
+	// after the manager instance is created.
+
+	return s.rootManager.chainParams
+}
+
+// AccountName returns the account name for the given account number stored in
+// the manager.
+func (s *ScopedKeyManager) AccountName(ns walletdb.ReadBucket, account uint32) (string, error) {
+	return fetchAccountName(ns, &s.scope, account)
+}
+
+// ForEachAccount calls the given function with each account stored in the
+// manager, breaking early on error.
+func (s *ScopedKeyManager) ForEachAccount(ns walletdb.ReadBucket,
+	fn func(account uint32) error) error {
+
+	return forEachAccount(ns, &s.scope, fn)
+}
+
+// LastAccount returns the last account stored in the manager.
+func (s *ScopedKeyManager) LastAccount(ns walletdb.ReadBucket) (uint32, error) {
+	return fetchLastAccount(ns, &s.scope)
+}
+
+// ForEachAccountAddress calls the given function with each address of the
+// given account stored in the manager, breaking early on error.
+func (s *ScopedKeyManager) ForEachAccountAddress(ns walletdb.ReadBucket,
+	account uint32, fn func(maddr ManagedAddress) error) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	addrFn := func(rowInterface interface{}) error {
+		managedAddr, err := s.rowInterfaceToManaged(ns, rowInterface)
+		if err != nil {
+			return err
+		}
+		return fn(managedAddr)
+	}
+	err := forEachAccountAddress(ns, &s.scope, account, addrFn)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	return nil
+}
+
+// ForEachActiveAccountAddress calls the given function with each active
+// address of the given account stored in the manager, breaking early on error.
+//
+// TODO(tuxcanfly): actually return only active addresses
+func (s *ScopedKeyManager) ForEachActiveAccountAddress(ns walletdb.ReadBucket, account uint32,
+	fn func(maddr ManagedAddress) error) error {
+
+	return s.ForEachAccountAddress(ns, account, fn)
+}
+
+// ForEachActiveAddress calls the given function with each active address
+// stored in the manager, breaking early on error.
+func (s *ScopedKeyManager) ForEachActiveAddress(ns walletdb.ReadBucket,
+	fn func(addr btcutil.Address) error) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	addrFn := func(rowInterface interface{}) error {
+		managedAddr, err := s.rowInterfaceToManaged(ns, rowInterface)
+		if err != nil {
+			return err
+		}
+		return fn(managedAddr.Address())
+	}
+
+	err := forEachActiveAddress(ns, &s.scope, addrFn)
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+
+	return nil
+}

--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -11,8 +11,8 @@ import (
 	"github.com/roasbeef/btcwallet/walletdb"
 )
 
-// BlockStamp defines a block (by height and a unique hash) and is
-// used to mark a point in the blockchain that an address manager element is
+// BlockStamp defines a block (by height and a unique hash) and is used to mark
+// a point in the blockchain that an address manager element is
 // synced to.
 type BlockStamp struct {
 	Height    int32
@@ -24,8 +24,8 @@ type BlockStamp struct {
 // seen blocks as height, as well as the start and current sync block stamps.
 type syncState struct {
 	// startBlock is the first block that can be safely used to start a
-	// rescan.  It is either the block the manager was created with, or
-	// the earliest block provided with imported addresses or scripts.
+	// rescan.  It is either the block the manager was created with, or the
+	// earliest block provided with imported addresses or scripts.
 	startBlock BlockStamp
 
 	// syncedTo is the current block the addresses in the manager are known
@@ -43,8 +43,8 @@ func newSyncState(startBlock, syncedTo *BlockStamp) *syncState {
 }
 
 // SetSyncedTo marks the address manager to be in sync with the recently-seen
-// block described by the blockstamp.  When the provided blockstamp is nil,
-// the oldest blockstamp of the block the manager was created at and of all
+// block described by the blockstamp.  When the provided blockstamp is nil, the
+// oldest blockstamp of the block the manager was created at and of all
 // imported addresses will be used.  This effectively allows the manager to be
 // marked as unsynced back to the oldest known point any of the addresses have
 // appeared in the block chain.

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -252,14 +252,14 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord, 
 	if block == nil {
 		details, err := w.TxStore.UniqueTxDetails(txmgrNs, &rec.Hash, nil)
 		if err != nil {
-			log.Errorf("Cannot query transaction details for notifiation: %v", err)
+			log.Errorf("Cannot query transaction details for notification: %v", err)
 		} else {
 			w.NtfnServer.notifyUnminedTransaction(dbtx, details)
 		}
 	} else {
 		details, err := w.TxStore.UniqueTxDetails(txmgrNs, &rec.Hash, &block.Block)
 		if err != nil {
-			log.Errorf("Cannot query transaction details for notifiation: %v", err)
+			log.Errorf("Cannot query transaction details for notification: %v", err)
 		} else {
 			w.NtfnServer.notifyMinedTransaction(dbtx, details, block)
 		}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -125,14 +125,15 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut, account uint32,
 
 		inputSource := makeInputSource(eligible)
 		changeSource := func() ([]byte, error) {
-			// Derive the change output script.  As a hack to allow spending from
-			// the imported account, change addresses are created from account 0.
+			// Derive the change output script.  As a hack to allow
+			// spending from the imported account, change addresses
+			// are created from account 0.
 			var changeAddr btcutil.Address
 			var err error
 			if account == waddrmgr.ImportedAddrAccount {
-				changeAddr, err = w.newChangeAddress(addrmgrNs, 0, waddrmgr.WitnessPubKey)
+				changeAddr, err = w.newChangeAddress(addrmgrNs, 0)
 			} else {
-				changeAddr, err = w.newChangeAddress(addrmgrNs, account, waddrmgr.WitnessPubKey)
+				changeAddr, err = w.newChangeAddress(addrmgrNs, account)
 			}
 			if err != nil {
 				return nil, err
@@ -145,9 +146,9 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut, account uint32,
 			return err
 		}
 
-		// Randomize change position, if change exists, before signing.  This
-		// doesn't affect the serialize size, so the change amount will still be
-		// valid.
+		// Randomize change position, if change exists, before signing.
+		// This doesn't affect the serialize size, so the change amount
+		// will still be valid.
 		if tx.ChangeIndex >= 0 {
 			tx.RandomizeChangePosition()
 		}
@@ -218,7 +219,7 @@ func (w *Wallet) findEligibleOutputs(dbtx walletdb.ReadTx, account uint32, minco
 		if err != nil || len(addrs) != 1 {
 			continue
 		}
-		addrAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
+		_, addrAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
 		if err != nil || addrAcct != account {
 			continue
 		}

--- a/wallet/multisig.go
+++ b/wallet/multisig.go
@@ -83,7 +83,16 @@ func (w *Wallet) ImportP2SHRedeemScript(script []byte) (*btcutil.AddressScriptHa
 			Height: 0,
 		}
 
-		addrInfo, err := w.Manager.ImportScript(addrmgrNs, script, bs)
+		// As this is a regular P2SH script, we'll import this into the
+		// BIP0044 scope.
+		bip44Mgr, err := w.Manager.FetchScopedKeyManager(
+			waddrmgr.KeyScopeBIP0084,
+		)
+		if err != nil {
+			return err
+		}
+
+		addrInfo, err := bip44Mgr.ImportScript(addrmgrNs, script, bs)
 		if err != nil {
 			// Don't care if it's already there, but still have to
 			// set the p2shAddr since the address manager didn't

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -67,7 +67,7 @@ func lookupInputAccount(dbtx walletdb.ReadTx, w *Wallet, details *wtxmgr.TxDetai
 	_, addrs, _, err := txscript.ExtractPkScriptAddrs(prevOut.PkScript, w.chainParams)
 	var inputAcct uint32
 	if err == nil && len(addrs) > 0 {
-		inputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+		_, inputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
 	}
 	if err != nil {
 		log.Errorf("Cannot fetch account for previous output %v: %v", prevOP, err)
@@ -163,7 +163,7 @@ func totalBalances(dbtx walletdb.ReadTx, w *Wallet, m map[uint32]btcutil.Amount)
 		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
 			output.PkScript, w.chainParams)
 		if err == nil && len(addrs) > 0 {
-			outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+			_, outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
 		}
 		if err == nil {
 			_, ok := m[outputAcct]

--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -56,7 +56,7 @@ func (w *Wallet) UnspentOutputs(policy OutputSelectionPolicy) ([]*TransactionOut
 				// per output.
 				continue
 			}
-			outputAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
+			_, outputAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
 			if err != nil {
 				return err
 			}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -839,7 +839,7 @@ func (w *Wallet) CalculateAccountBalances(account uint32, confirms int32) (Balan
 			_, addrs, _, err := txscript.ExtractPkScriptAddrs(
 				output.PkScript, w.chainParams)
 			if err == nil && len(addrs) > 0 {
-				outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+				_, outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
 			}
 			if err != nil || outputAcct != account {
 				continue
@@ -859,25 +859,30 @@ func (w *Wallet) CalculateAccountBalances(account uint32, confirms int32) (Balan
 }
 
 // CurrentAddress gets the most recently requested Bitcoin payment address
-// from a wallet.  If the address has already been used (there is at least
-// one transaction spending to it in the blockchain or btcd mempool), the next
-// chained address is returned.
-func (w *Wallet) CurrentAddress(account uint32) (btcutil.Address, error) {
+// from a wallet for a particular key-chain scope.  If the address has already
+// been used (there is at least one transaction spending to it in the
+// blockchain or btcd mempool), the next chained address is returned.
+func (w *Wallet) CurrentAddress(account uint32, scope waddrmgr.KeyScope) (btcutil.Address, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
 	var addr btcutil.Address
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		maddr, err := w.Manager.LastExternalAddress(addrmgrNs, account)
+		maddr, err := manager.LastExternalAddress(addrmgrNs, account)
 		if err != nil {
 			// If no address exists yet, create the first external address
 			if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
-				addr, err = w.newAddress(addrmgrNs, account, waddrmgr.WitnessPubKey)
+				addr, err = w.newAddress(addrmgrNs, account, scope)
 			}
 			return err
 		}
 
 		// Get next chained address if the last one has already been used.
 		if maddr.Used(addrmgrNs) {
-			addr, err = w.newAddress(addrmgrNs, account, waddrmgr.WitnessPubKey)
+			addr, err = w.newAddress(addrmgrNs, account, scope)
 			return err
 		}
 
@@ -949,7 +954,7 @@ func (w *Wallet) AccountOfAddress(a btcutil.Address) (uint32, error) {
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		var err error
-		account, err = w.Manager.AddrAccount(addrmgrNs, a)
+		_, account, err = w.Manager.AddrAccount(addrmgrNs, a)
 		return err
 	})
 	return account, err
@@ -967,25 +972,36 @@ func (w *Wallet) AddressInfo(a btcutil.Address) (waddrmgr.ManagedAddress, error)
 	return managedAddress, err
 }
 
-// AccountNumber returns the account number for an account name.
-func (w *Wallet) AccountNumber(accountName string) (uint32, error) {
+// AccountNumber returns the account number for an account name under a
+// particular key scope.
+func (w *Wallet) AccountNumber(scope waddrmgr.KeyScope, accountName string) (uint32, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return 0, err
+	}
+
 	var account uint32
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		var err error
-		account, err = w.Manager.LookupAccount(addrmgrNs, accountName)
+		account, err = manager.LookupAccount(addrmgrNs, accountName)
 		return err
 	})
 	return account, err
 }
 
 // AccountName returns the name of an account.
-func (w *Wallet) AccountName(accountNumber uint32) (string, error) {
+func (w *Wallet) AccountName(scope waddrmgr.KeyScope, accountNumber uint32) (string, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return "", err
+	}
+
 	var accountName string
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		var err error
-		accountName, err = w.Manager.AccountName(addrmgrNs, accountNumber)
+		accountName, err = manager.AccountName(addrmgrNs, accountNumber)
 		return err
 	})
 	return accountName, err
@@ -994,27 +1010,37 @@ func (w *Wallet) AccountName(accountNumber uint32) (string, error) {
 // AccountProperties returns the properties of an account, including address
 // indexes and name. It first fetches the desynced information from the address
 // manager, then updates the indexes based on the address pools.
-func (w *Wallet) AccountProperties(acct uint32) (*waddrmgr.AccountProperties, error) {
+func (w *Wallet) AccountProperties(scope waddrmgr.KeyScope, acct uint32) (*waddrmgr.AccountProperties, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
 	var props *waddrmgr.AccountProperties
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		var err error
-		props, err = w.Manager.AccountProperties(waddrmgrNs, acct)
+		props, err = manager.AccountProperties(waddrmgrNs, acct)
 		return err
 	})
 	return props, err
 }
 
 // RenameAccount sets the name for an account number to newName.
-func (w *Wallet) RenameAccount(account uint32, newName string) error {
+func (w *Wallet) RenameAccount(scope waddrmgr.KeyScope, account uint32, newName string) error {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return err
+	}
+
 	var props *waddrmgr.AccountProperties
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		err := w.Manager.RenameAccount(addrmgrNs, account, newName)
+		err := manager.RenameAccount(addrmgrNs, account, newName)
 		if err != nil {
 			return err
 		}
-		props, err = w.Manager.AccountProperties(addrmgrNs, account)
+		props, err = manager.AccountProperties(addrmgrNs, account)
 		return err
 	})
 	if err == nil {
@@ -1030,17 +1056,24 @@ const maxEmptyAccounts = 100
 // restoring, new accounts may not be created when all of the previous 100
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
-func (w *Wallet) NextAccount(name string) (uint32, error) {
-	var account uint32
-	var props *waddrmgr.AccountProperties
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+func (w *Wallet) NextAccount(scope waddrmgr.KeyScope, name string) (uint32, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return 0, err
+	}
+
+	var (
+		account uint32
+		props   *waddrmgr.AccountProperties
+	)
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		var err error
-		account, err = w.Manager.NewAccount(addrmgrNs, name)
+		account, err = manager.NewAccount(addrmgrNs, name)
 		if err != nil {
 			return err
 		}
-		props, err = w.Manager.AccountProperties(addrmgrNs, account)
+		props, err = manager.AccountProperties(addrmgrNs, account)
 		return err
 	})
 	if err != nil {
@@ -1169,9 +1202,9 @@ outputs:
 		if len(addrs) == 1 {
 			addr := addrs[0]
 			address = addr.EncodeAddress()
-			account, err := addrMgr.AddrAccount(addrmgrNs, addrs[0])
+			mgr, account, err := addrMgr.AddrAccount(addrmgrNs, addrs[0])
 			if err == nil {
-				accountName, err = addrMgr.AccountName(addrmgrNs, account)
+				accountName, err = mgr.AccountName(addrmgrNs, account)
 				if err != nil {
 					accountName = ""
 				}
@@ -1544,18 +1577,23 @@ type AccountsResult struct {
 }
 
 // Accounts returns the current names, numbers, and total balances of all
-// accounts in the wallet.  The current chain tip is included in the result for
-// atomicity reasons.
+// accounts in the wallet restricted to a particular key scope.  The current
+// chain tip is included in the result for atomicity reasons.
 //
 // TODO(jrick): Is the chain tip really needed, since only the total balances
 // are included?
-func (w *Wallet) Accounts() (*AccountsResult, error) {
+func (w *Wallet) Accounts(scope waddrmgr.KeyScope) (*AccountsResult, error) {
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		accounts        []AccountResult
 		syncBlockHash   *chainhash.Hash
 		syncBlockHeight int32
 	)
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 
@@ -1566,8 +1604,8 @@ func (w *Wallet) Accounts() (*AccountsResult, error) {
 		if err != nil {
 			return err
 		}
-		err = w.Manager.ForEachAccount(addrmgrNs, func(acct uint32) error {
-			props, err := w.Manager.AccountProperties(addrmgrNs, acct)
+		err = manager.ForEachAccount(addrmgrNs, func(acct uint32) error {
+			props, err := manager.AccountProperties(addrmgrNs, acct)
 			if err != nil {
 				return err
 			}
@@ -1590,7 +1628,7 @@ func (w *Wallet) Accounts() (*AccountsResult, error) {
 			var outputAcct uint32
 			_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript, w.chainParams)
 			if err == nil && len(addrs) > 0 {
-				outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+				_, outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
 			}
 			if err == nil {
 				amt, ok := m[outputAcct]
@@ -1618,22 +1656,29 @@ type AccountBalanceResult struct {
 // AccountBalances returns all accounts in the wallet and their balances.
 // Balances are determined by excluding transactions that have not met
 // requiredConfs confirmations.
-func (w *Wallet) AccountBalances(requiredConfs int32) ([]AccountBalanceResult, error) {
+func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
+	requiredConfs int32) ([]AccountBalanceResult, error) {
+
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
 	var results []AccountBalanceResult
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 
 		syncBlock := w.Manager.SyncedTo()
 
 		// Fill out all account info except for the balances.
-		lastAcct, err := w.Manager.LastAccount(addrmgrNs)
+		lastAcct, err := manager.LastAccount(addrmgrNs)
 		if err != nil {
 			return err
 		}
 		results = make([]AccountBalanceResult, lastAcct+2)
 		for i := range results[:len(results)-1] {
-			accountName, err := w.Manager.AccountName(addrmgrNs, uint32(i))
+			accountName, err := manager.AccountName(addrmgrNs, uint32(i))
 			if err != nil {
 				return err
 			}
@@ -1663,7 +1708,7 @@ func (w *Wallet) AccountBalances(requiredConfs int32) ([]AccountBalanceResult, e
 			if err != nil || len(addrs) == 0 {
 				continue
 			}
-			outputAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
+			outputAcct, err := manager.AddrAccount(addrmgrNs, addrs[0])
 			if err != nil {
 				continue
 			}
@@ -1724,7 +1769,9 @@ func (s creditSlice) Swap(i, j int) {
 // minconf, less than maxconf and if addresses is populated only the addresses
 // contained within it will be considered.  If we know nothing about a
 // transaction an empty array will be returned.
-func (w *Wallet) ListUnspent(minconf, maxconf int32, addresses map[string]struct{}) ([]*btcjson.ListUnspentResult, error) {
+func (w *Wallet) ListUnspent(minconf, maxconf int32,
+	addresses map[string]struct{}) ([]*btcjson.ListUnspentResult, error) {
+
 	var results []*btcjson.ListUnspentResult
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
@@ -1739,11 +1786,7 @@ func (w *Wallet) ListUnspent(minconf, maxconf int32, addresses map[string]struct
 		}
 		sort.Sort(sort.Reverse(creditSlice(unspent)))
 
-		defaultAccountName, err := w.Manager.AccountName(addrmgrNs,
-			waddrmgr.DefaultAccountNum)
-		if err != nil {
-			return err
-		}
+		defaultAccountName := "default"
 
 		results = make([]*btcjson.ListUnspentResult, 0, len(unspent))
 		for i := range unspent {
@@ -1782,9 +1825,9 @@ func (w *Wallet) ListUnspent(minconf, maxconf int32, addresses map[string]struct
 				continue
 			}
 			if len(addrs) > 0 {
-				acct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
+				smgr, acct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
 				if err == nil {
-					s, err := w.Manager.AccountName(addrmgrNs, acct)
+					s, err := smgr.AccountName(addrmgrNs, acct)
 					if err == nil {
 						acctName = s
 					}
@@ -1925,8 +1968,13 @@ func (w *Wallet) DumpWIFPrivateKey(addr btcutil.Address) (string, error) {
 
 // ImportPrivateKey imports a private key to the wallet and writes the new
 // wallet to disk.
-func (w *Wallet) ImportPrivateKey(wif *btcutil.WIF, bs *waddrmgr.BlockStamp,
-	rescan bool) (string, error) {
+func (w *Wallet) ImportPrivateKey(scope waddrmgr.KeyScope, wif *btcutil.WIF,
+	bs *waddrmgr.BlockStamp, rescan bool) (string, error) {
+
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return "", err
+	}
 
 	// The starting block for the key is the genesis block unless otherwise
 	// specified.
@@ -1948,15 +1996,16 @@ func (w *Wallet) ImportPrivateKey(wif *btcutil.WIF, bs *waddrmgr.BlockStamp,
 	// Attempt to import private key into wallet.
 	var addr btcutil.Address
 	var props *waddrmgr.AccountProperties
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		maddr, err := w.Manager.ImportPrivateKey(addrmgrNs, wif, bs)
+		maddr, err := manager.ImportPrivateKey(addrmgrNs, wif, bs)
 		if err != nil {
 			return err
 		}
 		addr = maddr.Address()
-		props, err = w.Manager.AccountProperties(
-			addrmgrNs, waddrmgr.ImportedAddrAccount)
+		props, err = manager.AccountProperties(
+			addrmgrNs, waddrmgr.ImportedAddrAccount,
+		)
 		if err != nil {
 			return err
 		}
@@ -2122,21 +2171,28 @@ func (w *Wallet) SortedActivePaymentAddresses() ([]string, error) {
 }
 
 // NewAddress returns the next external chained address for a wallet.
-func (w *Wallet) NewAddress(account uint32, addrType waddrmgr.AddressType) (addr btcutil.Address, err error) {
+func (w *Wallet) NewAddress(account uint32,
+	scope waddrmgr.KeyScope) (addr btcutil.Address, err error) {
+
 	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		var err error
-		addr, err = w.newAddress(addrmgrNs, account, addrType)
+		addr, err = w.newAddress(addrmgrNs, account, scope)
 		return err
 	})
 	return
 }
 
 func (w *Wallet) newAddress(addrmgrNs walletdb.ReadWriteBucket, account uint32,
-	addrType waddrmgr.AddressType) (btcutil.Address, error) {
+	scope waddrmgr.KeyScope) (btcutil.Address, error) {
+
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get next address from wallet.
-	addrs, err := w.Manager.NextExternalAddresses(addrmgrNs, account, 1, addrType)
+	addrs, err := manager.NextExternalAddresses(addrmgrNs, account, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -2156,7 +2212,7 @@ func (w *Wallet) newAddress(addrmgrNs walletdb.ReadWriteBucket, account uint32,
 		}
 	}
 
-	props, err := w.Manager.AccountProperties(addrmgrNs, account)
+	props, err := manager.AccountProperties(addrmgrNs, account)
 	if err != nil {
 		log.Errorf("Cannot fetch account properties for notification "+
 			"after deriving next external address: %v", err)
@@ -2168,21 +2224,31 @@ func (w *Wallet) newAddress(addrmgrNs walletdb.ReadWriteBucket, account uint32,
 }
 
 // NewChangeAddress returns a new change address for a wallet.
-func (w *Wallet) NewChangeAddress(account uint32, addrType waddrmgr.AddressType) (addr btcutil.Address, err error) {
+func (w *Wallet) NewChangeAddress(account uint32, scope waddrmgr.KeyScope) (addr btcutil.Address, err error) {
 	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		var err error
-		addr, err = w.newChangeAddress(addrmgrNs, account, addrType)
+		addr, err = w.newChangeAddress(addrmgrNs, account)
 		return err
 	})
 	return
 }
 
 func (w *Wallet) newChangeAddress(addrmgrNs walletdb.ReadWriteBucket,
-	account uint32, addrType waddrmgr.AddressType) (btcutil.Address, error) {
+	account uint32) (btcutil.Address, error) {
+
+	// As we're making a change address, we'll fetch the type of manager
+	// that is able to make p2wkh output as they're the most efficient.
+	scopes := w.Manager.ScopesForExternalAddrType(
+		waddrmgr.WitnessPubKey,
+	)
+	manager, err := w.Manager.FetchScopedKeyManager(scopes[0])
+	if err != nil {
+		return nil, err
+	}
 
 	// Get next chained change address from wallet for account.
-	addrs, err := w.Manager.NextInternalAddresses(addrmgrNs, account, 1, addrType)
+	addrs, err := manager.NextInternalAddresses(addrmgrNs, account, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -2232,17 +2298,24 @@ type AccountTotalReceivedResult struct {
 }
 
 // TotalReceivedForAccounts iterates through a wallet's transaction history,
-// returning the total amount of decred received for all accounts.
-func (w *Wallet) TotalReceivedForAccounts(minConf int32) ([]AccountTotalReceivedResult, error) {
+// returning the total amount of Bitcoin received for all accounts.
+func (w *Wallet) TotalReceivedForAccounts(scope waddrmgr.KeyScope,
+	minConf int32) ([]AccountTotalReceivedResult, error) {
+
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
 	var results []AccountTotalReceivedResult
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 
 		syncBlock := w.Manager.SyncedTo()
 
-		err := w.Manager.ForEachAccount(addrmgrNs, func(account uint32) error {
-			accountName, err := w.Manager.AccountName(addrmgrNs, account)
+		err := manager.ForEachAccount(addrmgrNs, func(account uint32) error {
+			accountName, err := manager.AccountName(addrmgrNs, account)
 			if err != nil {
 				return err
 			}
@@ -2272,7 +2345,7 @@ func (w *Wallet) TotalReceivedForAccounts(minConf int32) ([]AccountTotalReceived
 					var outputAcct uint32
 					_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkScript, w.chainParams)
 					if err == nil && len(addrs) > 0 {
-						outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+						_, outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
 					}
 					if err == nil {
 						acctIndex := int(outputAcct)

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -69,7 +69,8 @@ func convertLegacyKeystore(legacyKeyStore *keystore.Store, w *wallet.Wallet) err
 				continue
 			}
 
-			_, err = w.ImportPrivateKey(wif, &blockStamp, false)
+			_, err = w.ImportPrivateKey(waddrmgr.KeyScopeBIP0044,
+				wif, &blockStamp, false)
 			if err != nil {
 				fmt.Printf("WARN: Failed to import private "+
 					"key for address %v: %v\n",


### PR DESCRIPTION
In this PR, we aim to generalize the `waddrmgr` in order to allow callers to have a higher degree of control over they way they perform key derivation. As is now, the wallet _assumes_ BIP44. My earlier stab at implementing segwit support was a bit of a hack, as it re-used the BIP44 key chain, but then instead marked it the database how to "render" the address for each key. This also would present issue in the case of restoration, as for each key, we'd need to look for _each_ each type of address, blowing up the state required significantly. 

To fix these issues, and also create a path for more flexible key derivation within `lnd`, the current `Manager` is now referred to as a `RootManager`. A big change in this process, is that we'll now actually store the root HD key as well. This is required in order to derive new (purpose, cointype) pairs, that we calls scopes. Many methods on the `Manager` struct have been moved to the `ScopedKeyManager`, and a few new methods have been added in order to target operations by a specific scope, or two create new scopes, etc. 

We also add two new default scopes (in addition to BIP44):
   * BIP 49++
   * BIP 84

BIP 49++ is BIP 49, but using `p2wkh` for change addresses as well. While BIP 84 is similar to BIP 49, but uses pure `p2wkh` addresses for all key derivation. 