### PR TITLE
Improve fee estimation for segwit transactions

### DIFF
--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -5,6 +5,7 @@
 package txsizes
 
 import (
+	"github.com/roasbeef/btcd/blockchain"
 	"github.com/roasbeef/btcd/wire"
 
 	h "github.com/roasbeef/btcwallet/internal/helpers"
@@ -52,7 +53,69 @@ const (
 	//   - 25 bytes P2PKH output script
 	P2PKHOutputSize = 8 + 1 + P2PKHPkScriptSize
 
-	// TODO(roasbeef): add estimates for nested p2wkh and p2pkh
+	// P2WPKHPkScriptSize is the size of a transaction output script that
+	// pays to a witness pubkey hash. It is calculated as:
+	//
+	//   - OP_0
+	//   - OP_DATA_20
+	//   - 20 bytes pubkey hash
+	P2WPKHPkScriptSize = 1 + 1 + 20
+
+	// P2WPKHOutputSize is the serialize size of a transaction output with a
+	// P2WPKH output script. It is calculated as:
+	//
+	//   - 8 bytes output value
+	//   - 1 byte compact int encoding value 22
+	//   - 22 bytes P2PKH output script
+	P2WPKHOutputSize = 8 + 1 + P2WPKHPkScriptSize
+
+	// RedeemP2WPKHScriptSize is the size of a transaction input script
+	// that spends a pay-to-witness-public-key hash (P2WPKH). The redeem
+	// script for P2WPKH spends MUST be empty.
+	RedeemP2WPKHScriptSize = 0
+
+	// RedeemP2WPKHInputSize is the worst case size of a transaction
+	// input redeeming a P2WPKH output. It is calculated as:
+	//
+	//   - 32 bytes previous tx
+	//   - 4 bytes output index
+	//   - 1 byte encoding empty redeem script
+	//   - 0 bytes redeem script
+	//   - 4 bytes sequence
+	RedeemP2WPKHInputSize = 32 + 4 + 1 + RedeemP2WPKHScriptSize + 4
+
+	// RedeemNestedP2WPKHScriptSize is the worst case size of a transaction
+	// input script that redeems a pay-to-witness-key hash nested in P2SH
+	// (P2SH-P2WPKH). It is calculated as:
+	//
+	//   - 1 byte compact int encoding value 22
+	//   - OP_0
+	//   - 1 byte compact int encoding value 20
+	//   - 20 byte key hash
+	RedeemNestedP2WPKHScriptSize = 1 + 1 + 1 + 20
+
+	// RedeemNestedP2WPKHInputSize is the worst case size of a
+	// transaction input redeeming a P2SH-P2WPKH output. It is
+	// calculated as:
+	//
+	//   - 32 bytes previous tx
+	//   - 4 bytes output index
+	//   - 1 byte compact int encoding value 23
+	//   - 23 bytes redeem script (scriptSig)
+	//   - 4 bytes sequence
+	RedeemNestedP2WPKHInputSize = 32 + 4 + 1 +
+		RedeemNestedP2WPKHScriptSize + 4
+
+	// RedeemP2WPKHInputWitnessWeight is the worst case weight of
+	// a witness for spending P2WPKH and nested P2WPKH outputs. It
+	// is calculated as:
+	//
+	//   - 1 wu compact int encoding value 2 (number of items)
+	//   - 1 wu compact int encoding value 73
+	//   - 72 wu DER signature + 1 wu sighash
+	//   - 1 wu compact int encoding value 33
+	//   - 33 wu serialized compressed pubkey
+	RedeemP2WPKHInputWitnessWeight = 1 + 1 + 73 + 1 + 33
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a
@@ -73,4 +136,49 @@ func EstimateSerializeSize(inputCount int, txOuts []*wire.TxOut, addChangeOutput
 		inputCount*RedeemP2PKHInputSize +
 		h.SumOutputSerializeSizes(txOuts) +
 		changeSize
+}
+
+// EstimateVirtualSize returns a worst case virtual size estimate for a
+// signed transaction that spends the given number of P2PKH, P2WPKH and
+// (nested) P2SH-P2WPKH outputs, and contains each transaction output
+// from txOuts. The estimate is incremented for an additional P2PKH
+// change output if addChangeOutput is true.
+func EstimateVirtualSize(numP2PKHIns, numP2WPKHIns, numNestedP2WPKHIns int,
+	txOuts []*wire.TxOut, addChangeOutput bool) int {
+	changeSize := 0
+	outputCount := len(txOuts)
+	if addChangeOutput {
+		// We are always using P2WPKH as change output.
+		changeSize = P2WPKHOutputSize
+		outputCount++
+	}
+
+	// Version 4 bytes + LockTime 4 bytes + Serialized var int size for the
+	// number of transaction inputs and outputs + size of redeem scripts +
+	// the size out the serialized outputs and change.
+	baseSize := 8 +
+		wire.VarIntSerializeSize(
+			uint64(numP2PKHIns+numP2WPKHIns+numNestedP2WPKHIns)) +
+		wire.VarIntSerializeSize(uint64(len(txOuts))) +
+		numP2PKHIns*RedeemP2PKHInputSize +
+		numP2WPKHIns*RedeemP2WPKHInputSize +
+		numNestedP2WPKHIns*RedeemNestedP2WPKHInputSize +
+		h.SumOutputSerializeSizes(txOuts) +
+		changeSize
+
+	// If this transaction has any witness inputs, we must count the
+	// witness data.
+	witnessWeight := 0
+	if numP2WPKHIns+numNestedP2WPKHIns > 0 {
+		// Additional 2 weight units for segwit marker + flag.
+		witnessWeight = 2 +
+			wire.VarIntSerializeSize(
+				uint64(numP2WPKHIns+numNestedP2WPKHIns)) +
+			numP2WPKHIns*RedeemP2WPKHInputWitnessWeight +
+			numNestedP2WPKHIns*RedeemP2WPKHInputWitnessWeight
+	}
+
+	// We add 3 to the witness weight to make sure the result is
+	// always rounded up.
+	return baseSize + (witnessWeight+3)/blockchain.WitnessScaleFactor
 }

--- a/wallet/internal/txsizes/size_test.go
+++ b/wallet/internal/txsizes/size_test.go
@@ -1,6 +1,8 @@
 package txsizes_test
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/roasbeef/btcd/wire"
@@ -57,6 +59,97 @@ func TestEstimateSerializeSize(t *testing.T) {
 		actualEstimate := EstimateSerializeSize(test.InputCount, outputs, test.AddChangeOutput)
 		if actualEstimate != test.ExpectedSizeEstimate {
 			t.Errorf("Test %d: Got %v: Expected %v", i, actualEstimate, test.ExpectedSizeEstimate)
+		}
+	}
+}
+
+func TestEstimateVirtualSize(t *testing.T) {
+
+	type estimateVSizeTest struct {
+		tx             func() (*wire.MsgTx, error)
+		p2wkhIns       int
+		nestedP2wkhIns int
+		change         bool
+		result         int
+	}
+
+	// TODO(halseth): add tests for more combination out inputs/outputs.
+	tests := []estimateVSizeTest{
+		// Spending P2WPKH to two outputs. Example adapted from example in BIP-143.
+		{
+			tx: func() (*wire.MsgTx, error) {
+				txHex := "01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac0247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000"
+				b, err := hex.DecodeString(txHex)
+				if err != nil {
+					return nil, err
+				}
+				tx := &wire.MsgTx{}
+				err = tx.Deserialize(bytes.NewReader(b))
+				if err != nil {
+					return nil, err
+				}
+
+				return tx, nil
+			},
+			p2wkhIns: 1,
+			result:   147,
+		},
+		{
+			// Spending P2SH-P2WPKH to two outputs. Example adapted from example in BIP-143.
+			tx: func() (*wire.MsgTx, error) {
+				txHex := "01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000001716001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000"
+				b, err := hex.DecodeString(txHex)
+				if err != nil {
+					return nil, err
+				}
+				tx := &wire.MsgTx{}
+				err = tx.Deserialize(bytes.NewReader(b))
+				if err != nil {
+					return nil, err
+				}
+
+				return tx, nil
+			},
+			nestedP2wkhIns: 1,
+			result:         170,
+		},
+		{
+			// Spendin P2WPKH to on output, adding one change output. We reuse
+			// the transaction spending to two outputs, removing one of them.
+			tx: func() (*wire.MsgTx, error) {
+				txHex := "01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac0247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000"
+				b, err := hex.DecodeString(txHex)
+				if err != nil {
+					return nil, err
+				}
+				tx := &wire.MsgTx{}
+				err = tx.Deserialize(bytes.NewReader(b))
+				if err != nil {
+					return nil, err
+				}
+
+				// Only keep the first output.
+				tx.TxOut = []*wire.TxOut{tx.TxOut[0]}
+				return tx, nil
+			},
+			p2wkhIns: 1,
+			change:   true,
+			result:   144,
+		},
+	}
+
+	for _, test := range tests {
+		tx, err := test.tx()
+		if err != nil {
+			t.Fatalf("unable to get test tx: %v", err)
+		}
+
+		est := EstimateVirtualSize(0, test.p2wkhIns,
+			test.nestedP2wkhIns, tx.TxOut, test.change)
+
+		if est != test.result {
+			t.Fatalf("expected estimated vsize to be %d, "+
+				"instead got %d", test.result, est)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a method for estimating the vsize of a transaction, making fee estimation more accurate for segwit transactions.