### PR TITLE
wtxmgr+wallet: ensure we remove discovered double spends, make tx reliable broadcast general 

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2544,26 +2544,20 @@ func (w *Wallet) PublishTransaction(tx *wire.MsgTx) error {
 		return err
 	}
 
-	switch server.(type) {
-	// If our chain backend is neutrino, then we'll add this as an
-	// unconfirmed transaction into the transaction store. Otherwise, we
-	// won't eve be notified of it's acceptance, meaning we won't attempt
-	// to re-broadcast.
-	case *chain.NeutrinoClient:
-		rec, err := wtxmgr.NewTxRecordFromMsgTx(
-			tx, time.Now(),
-		)
-		if err != nil {
-			return err
-		}
-		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-			txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-			return w.TxStore.InsertTx(txmgrNs, rec, nil)
-		})
-		if err != nil {
-			return err
-		}
+	// As we aim for this to be general reliable transaction broadcast API,
+	// we'll write this tx to disk as an unconfirmed transaction. This way,
+	// upon restarts, we'll always rebroadcast it, and also add it to our
+	// set of records.
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	if err != nil {
+		return err
+	}
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		return w.TxStore.InsertTx(txmgrNs, rec, nil)
+	})
+	if err != nil {
+		return err
 	}
 
 	_, err = server.SendRawTransaction(tx, false)

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -317,6 +317,19 @@ func (s *Store) InsertTx(ns walletdb.ReadWriteBucket, rec *TxRecord, block *Bloc
 	return s.insertMinedTx(ns, rec, block)
 }
 
+// RemoveUnminedTx attempts to remove an unmined transaction from the
+// transaction store. This is to be used in the scenario that a transaction
+// that we attempt to rebroadcast, turns out to double spend one of our
+// existing inputs. This function we remove the conflicting transaction
+// identified by the tx record, and also recursively remove all transactions
+// that depend on it.
+func (s *Store) RemoveUnminedTx(ns walletdb.ReadWriteBucket, rec *TxRecord) error {
+	// As we already have a tx record, we can directly call the
+	// removeConflict method. This will do the job of recursively removing
+	// this unmined transaction, and any transactions that depend on it.
+	return s.removeConflict(ns, rec)
+}
+
 // insertMinedTx inserts a new transaction record for a mined transaction into
 // the database.  It is expected that the exact transation does not already
 // exist in the unmined buckets, but unmined double spends (including mutations)


### PR DESCRIPTION
In this PR, we make two changes to the internal core wallet, and the `wtxmgr` that addresses some issues we've encountered in our usage within `lnd`. 


## `wtxmgr`
First, in the `wxtmgr`, we've added a new method that allows callers to remove conflicted unmined transactions. At times, it’s the case that while we were offline another transaction was broadcast that double spends our own, or with the existence of RBF, another replacement transaction was generated. In this case, when we come back online, the tx will be rejected. Currently, we have no way of removing such transaction sot avoid the retransmit-then-reject-dance. This commit fixes that by adding RemoveUnminedTx.

## `wallet`

Next, in the core `wallet`, we:
  * extend the PublishTransction method to be a more general semi reliable transaction broadcast mechanism. We do this by removing the special casing for neutrino. With this change, we’ll _always_ write any transactions to be broadcast to disk. A side effect of this, is that if the transaction doesn’t *directly* involve any outputs we control, then it’ll linger around until a restart, when we try to rebroadcast, and observe that it has bene rejected.
   * address a lingering TODO to remove conflicting transactions discovered when we go to re broadcast unmined transactions. 
