### PR TITLE
waddrmgr/multi: fix scoped mgr reentry deadlock

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -280,7 +280,7 @@ func (a *managedAddress) PrivKey() (*btcec.PrivateKey, error) {
 	defer a.manager.mtx.Unlock()
 
 	// Account manager must be unlocked to decrypt the private key.
-	if a.manager.rootManager.Locked() {
+	if a.manager.rootManager.IsLocked() {
 		return nil, managerError(ErrLocked, errLocked, nil)
 	}
 
@@ -586,7 +586,7 @@ func (a *scriptAddress) Script() ([]byte, error) {
 	defer a.manager.mtx.Unlock()
 
 	// Account manager must be unlocked to decrypt the script.
-	if a.manager.rootManager.Locked() {
+	if a.manager.rootManager.IsLocked() {
 		return nil, managerError(ErrLocked, errLocked, nil)
 	}
 

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -300,14 +300,6 @@ type Manager struct {
 	hashedPrivPassphrase [sha512.Size]byte
 }
 
-// Locked returns true if the root manager is locked, and false otherwise.
-func (m *Manager) Locked() bool {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	return m.locked
-}
-
 // WatchOnly returns true if the root manager is in watch only mode, and false
 // otherwise.
 func (m *Manager) WatchOnly() bool {
@@ -977,6 +969,15 @@ func (m *Manager) IsLocked() bool {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
+	return m.isLocked()
+}
+
+// isLocked is an internal method returning whether or not the address manager
+// is locked via an unprotected read.
+//
+// NOTE: The caller *MUST* acquire the Manager's mutex before invocation to
+// avoid data races.
+func (m *Manager) isLocked() bool {
 	return m.locked
 }
 


### PR DESCRIPTION
This commit resolves a deadlock observed when attempting
to generate addresses. There were a few cases, particularly
in `chainAddressRowToManaged` and `loadAccountInfo`, which accessed
the public `IsLocked()` method of the `Manager`, even though the
shared mutex had already been acquired.

The solution is to create an internal `isLocked()` method, which
can be safely called assuming the `Manager`'s mutex has already been
acquired. As the comments above both of the methods in question
specify, this is a safe assumption internal to the above methods.

This commit also reduces some unnecessary code duplication, since
the recent changes left both a `Locked()` and `IsLocked()` method that
perform the same functionality. `IsLocked()` was favored as it more
clearly indicates that the returned value is a boolean.