### PR TITLE
On rollback, ask the chain using the chainhash

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -488,7 +488,7 @@ func (w *Wallet) syncWithChain() error {
 			if err != nil {
 				return err
 			}
-			header, err := chainClient.GetBlockHeader(hash)
+			header, err := chainClient.GetBlockHeader(chainHash)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When debugging a block which ended up being rolled back, the chain (neutrino in this case) was being asked for the header of the rolled-back block, and failed to get the header since it was already rolled back. Don't know the code particularly well, but it seemed like asking the chain using the chain's blockhash worked (and the only code using the chain header is the timestamp). This seemed to fix the issue.

