### PR TITLE
Tolerate bitcoind supporting simnet

### DIFF
--- a/chain/bitcoind.go
+++ b/chain/bitcoind.go
@@ -108,6 +108,8 @@ func (c *BitcoindClient) GetCurrentNet() (wire.BitcoinNet, error) {
 	}
 
 	switch *hash {
+	case *chaincfg.SimNetParams.GenesisHash:
+		return chaincfg.SimNetParams.Net, nil
 	case *chaincfg.TestNet3Params.GenesisHash:
 		return chaincfg.TestNet3Params.Net, nil
 	case *chaincfg.RegressionNetParams.GenesisHash:


### PR DESCRIPTION
I have a patch for bitcoind that adds simnet support, in place of regtest. To have simnet work, this patch is necessary. Granted, that code path will never be used with vanilla bitcoind, but I don't see any disadvantage of adding this patch, since lnd is already preventing launching with bitcoind/simnet. Of course I have patched this, but I would like to avoid also forking the dependents of lnd.