### PR TITLE
wallet: remove transactions if rejected from mempool, catch all rejects upon restart retransmission

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2716,20 +2716,54 @@ func (w *Wallet) PublishTransaction(tx *wire.MsgTx) error {
 	// we'll write this tx to disk as an unconfirmed transaction. This way,
 	// upon restarts, we'll always rebroadcast it, and also add it to our
 	// set of records.
-	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
 	if err != nil {
 		return err
 	}
 	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-		return w.TxStore.InsertTx(txmgrNs, rec, nil)
+		return w.TxStore.InsertTx(txmgrNs, txRec, nil)
 	})
 	if err != nil {
 		return err
 	}
 
 	_, err = server.SendRawTransaction(tx, false)
-	return err
+	switch {
+	// The following are errors returned from btcd's mempool.
+	case strings.Contains(err.Error(), "spent"):
+		fallthrough
+	case strings.Contains(err.Error(), "orphan"):
+		fallthrough
+	case strings.Contains(err.Error(), "conflict"):
+		fallthrough
+
+	// The following errors are returned from bitcoind's mempool.
+	case strings.Contains(err.Error(), "fee not met"):
+		fallthrough
+	case strings.Contains(err.Error(), "Missing inputs"):
+		fallthrough
+	case strings.Contains(err.Error(), "already in block chain"):
+
+		// If the transaction was rejected, then we'll remove it from
+		// the txstore, as otherwise, we'll attempt to continually
+		// re-broadcast it, and the utxo state of the wallet won't be
+		// accurate.
+		dbErr := walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
+			txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+			return w.TxStore.RemoveUnminedTx(txmgrNs, txRec)
+		})
+		if dbErr != nil {
+			return fmt.Errorf("unable to broadcast tx: %v, "+
+				"unable to remove invalid tx: %v", err, dbErr)
+		}
+
+		return err
+
+	default:
+		return err
+	}
 }
 
 // ChainParams returns the network parameters for the blockchain the wallet


### PR DESCRIPTION
In this PR, ensure that upon restart, if any of the full-node based backends we support reject the transaction, then we'll properly remove the now invalid transaction from the tx store. Before this commit, we could miss a few errors from bitcoind. To remedy this, we explicitly catch those errors, but then also attempt to precisely catch the set of generic json RPC errors that can be returned.

We also ensure that if a transaction we try to send is rejected, then we'll remove it from the txstore to ensure that we don't try to retransmit it later, and also to ensure that the UTXO state of the wallet is correct. 